### PR TITLE
tests: Add integration test for KBS encrypted OCI image 

### DIFF
--- a/scripts/build_attestation_agent.sh
+++ b/scripts/build_attestation_agent.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[ -n "${BASH_VERSION:-}" ] && set -o errtrace
+[ -n "${DEBUG:-}" ] && set -o xtrace
+
+source $HOME/.cargo/env
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+AA_DIR=$SCRIPT_DIR/attestation_agent
+
+pushd $SCRIPT_DIR
+git clone --depth 1 "https://github.com/confidential-containers/attestation-agent.git" $AA_DIR
+pushd $AA_DIR
+make KBC=sample_kbc
+make DESTDIR="$SCRIPT_DIR" install
+popd
+
+cleanup() {
+  rm -rf "$AA_DIR"
+}
+trap cleanup EXIT

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use image_rs::image::ImageClient;
+    use std::path::Path;
+    use std::process::{Child, Command};
+
+    fn start_attestation_agent() -> Result<Child> {
+        let script_dir = format!("{}/{}", std::env!("CARGO_MANIFEST_DIR"), "scripts");
+        let aa_path = format!("{}/{}", script_dir, "attestation-agent");
+
+        if !Path::new(&aa_path).exists() {
+            let script_path = format!("{}/{}", script_dir, "build_attestation_agent.sh");
+            Command::new(script_path)
+                .output()
+                .expect("Failed to build attestation-agent");
+        }
+
+        Ok(Command::new(aa_path)
+            .args(&["--keyprovider_sock"])
+            .args(&["127.0.0.1:48888"])
+            .spawn()?)
+    }
+
+    #[tokio::test]
+    async fn test_image_rs() {
+        let mut aa = start_attestation_agent().expect("Failed to start attestation agent!");
+
+        let manifest_dir = std::env!("CARGO_MANIFEST_DIR");
+        let image = "docker.io/arronwang/busybox_kbs_encrypted";
+
+        let keyprovider_config =
+            format!("{}/{}", manifest_dir, "test_data/ocicrypt_keyprovider.conf");
+        std::env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", keyprovider_config);
+        let decrypt_config = "provider:attestation-agent:sample_kbc::null";
+
+        let work_dir = tempfile::tempdir().unwrap();
+        std::env::set_var("CC_IMAGE_WORK_DIR", &work_dir.path());
+        let bundle_dir = tempfile::tempdir().unwrap();
+
+        let mut image_client = ImageClient::default();
+        assert!(image_client
+            .pull_image(image, bundle_dir.path(), &None, &Some(decrypt_config))
+            .await
+            .is_ok());
+
+        aa.kill().expect("Failed to stop attestation agent!");
+    }
+}


### PR DESCRIPTION
    Current unit tests in pull module only covered the tests for container
    image encrypted by a public key file.

    The integration test verify the container images encrypted by an KBS.
    How to create KBS encrypted container image is documented in:
    test_data/generate_test_data.md

    It will first launch an attestation-agent daemon build
    with sample KBS support. Then it will try to pull an KBS encrypted
    container image to verify pull_image API.
