### PR TITLE
CI: Install nettle-sys building dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Install nettle-sys building dependence
+        run: |
+          sudo apt install clang llvm pkg-config nettle-dev
+
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
The signature verification module relies on `sequoia-openpgp`, and `sequoia-openpgp` relies on nettle-sys. To build nettle-sys successfully, `clang` `llvm` `pkg-config` `nettle-dev` must be installed in the test environment.