### PR TITLE
Refine create_runtime_config()

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -14,7 +14,10 @@ pub const BUNDLE_ROOTFS: &str = "rootfs";
 pub const BUNDLE_HOSTNAME: &str = "image-rs";
 
 const ANNOTATION_OS: &str = "org.opencontainers.image.os";
+const ANNOTATION_OS_VERSION: &str = "org.opencontainers.image.os.version";
+const ANNOTATION_OS_FEATURES: &str = "org.opencontainers.image.os.features";
 const ANNOTATION_ARCH: &str = "org.opencontainers.image.architecture";
+const ANNOTATION_VARIANT: &str = "org.opencontainers.image.variant";
 const ANNOTATION_AUTHOR: &str = "org.opencontainers.image.author";
 const ANNOTATION_CREATED: &str = "org.opencontainers.image.created";
 const ANNOTATION_STOP_SIGNAL: &str = "org.opencontainers.image.stopSignal";
@@ -166,11 +169,28 @@ pub fn create_runtime_config(
     if !labels.contains_key(ANNOTATION_OS) {
         annotations.insert(ANNOTATION_OS.to_string(), image_config.os().to_string());
     }
+    if !labels.contains_key(ANNOTATION_OS_VERSION) {
+        if let Some(version) = image_config.os_version() {
+            annotations.insert(ANNOTATION_OS_VERSION.to_string(), version.to_string());
+        }
+    }
+    if !labels.contains_key(ANNOTATION_OS_FEATURES) {
+        if let Some(features) = image_config.os_features() {
+            if let Ok(v) = serde_json::to_string(features) {
+                annotations.insert(ANNOTATION_OS_FEATURES.to_string(), v);
+            }
+        }
+    }
     if !labels.contains_key(ANNOTATION_ARCH) {
         annotations.insert(
             ANNOTATION_ARCH.to_string(),
             image_config.architecture().to_string(),
         );
+    }
+    if !labels.contains_key(ANNOTATION_VARIANT) {
+        if let Some(variant) = image_config.variant() {
+            annotations.insert(ANNOTATION_VARIANT.to_string(), variant.to_string());
+        }
     }
     if !labels.contains_key(ANNOTATION_AUTHOR) {
         if let Some(author) = image_config.author() {

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -20,15 +20,25 @@ const ANNOTATION_CREATED: &str = "org.opencontainers.image.created";
 const ANNOTATION_STOP_SIGNAL: &str = "org.opencontainers.image.stopSignal";
 const ANNOTATION_EXPOSED_PORTS: &str = "org.opencontainers.image.exposedPorts";
 
-/// create_runtime_config will create the config.json file under the bundle_path,
-/// and return the final bundle config path.
+/// Convert an `application/vnd.oci.image.config.v1+json` object into an OCI runtime configuration
+/// blob and write to `config.json`.
+///
+/// [OCI Image Spec: Conversion to OCI Runtime Configuration](https://github.com/opencontainers/image-spec/blob/main/conversion.md)
+/// states:
+///
+/// The "default generated runtime configuration" MAY be overridden or combined with externally
+/// provided inputs from the caller. In addition, a converter MAY have its own
+/// implementation-defined defaults and extensions which MAY be combined with the "default generated
+/// runtime configuration".
 pub fn create_runtime_config(
     image_config: &ImageConfiguration,
     bundle_path: &Path,
 ) -> Result<PathBuf> {
     let mut spec = Spec::default();
 
+    // Update the default hostname of `youki`
     spec.set_hostname(Some(BUNDLE_HOSTNAME.to_string()));
+
     let mut annotations: HashMap<String, String> = HashMap::new();
     annotations.insert(ANNOTATION_OS.to_string(), image_config.os().to_string());
     annotations.insert(
@@ -41,39 +51,88 @@ pub fn create_runtime_config(
     if let Some(created) = image_config.created() {
         annotations.insert(ANNOTATION_CREATED.to_string(), created.to_string());
     }
-    let mut process = Process::default();
 
     if let Some(config) = image_config.config() {
+        let mut process = Process::default();
+
+        // Verbatim Fields:
+        //
+        // A compliant configuration converter MUST extract the following fields verbatim to the
+        // corresponding field in the generated runtime configuration:
+        // - WorkingDir
+        // - Env
+        // - EntryPoint
+        // - Cmd
         if let Some(working_dir) = config.working_dir() {
             process.set_cwd(PathBuf::from(working_dir));
         }
-
+        // The converter MAY add additional entries to process.env but it SHOULD NOT add entries
+        // that have variable names present in Config.Env.
         if let Some(env) = config.env() {
             process.set_env(Some(env.to_vec()));
         }
-
+        // If both Config.Entrypoint and Config.Cmd are specified, the converter MUST append the
+        // value of Config.Cmd to the value of Config.Entrypoint and set process.args to that
+        // combined value.
         let mut args: Vec<String> = vec![];
         if let Some(entrypoint) = config.entrypoint() {
             args.extend(entrypoint.clone());
         }
-
         if let Some(cmd) = config.cmd() {
             args.extend(cmd.clone());
         }
-
         if !args.is_empty() {
             process.set_args(Some(args));
         }
 
+        // Annotation Fields
         if let Some(labels) = config.labels() {
             annotations.extend(labels.clone());
         }
+        if let Some(stop_signal) = config.stop_signal() {
+            annotations.insert(ANNOTATION_STOP_SIGNAL.to_string(), stop_signal.to_string());
+        }
 
+        // Parsed Fields:
+        //
+        // Certain image configuration fields have a counterpart that must first be translated.
+        // A compliant configuration converter SHOULD parse all of these fields and set the
+        // corresponding fields in the generated runtime configuration:
+        // - User
         // TODO: parse image config user info and extract uid from rootfs passwd file
         // github issue: https://github.com/confidential-containers/image-rs/issues/8
 
-        let mut mounts: Vec<Mount> = vec![];
+        // Optional Fields:
+        //
+        // Certain image configuration fields are not applicable to all conversion use cases, and
+        // thus are optional for configuration converters to implement. A compliant configuration
+        // converter SHOULD provide a way for users to extract these fields into the generated
+        // runtime configuration:
+        // - ExposedPorts
+        // - Volumes
+
+        // The runtime configuration does not have a corresponding field for this image field.
+        // However, converters SHOULD set the org.opencontainers.image.exposedPorts annotation.
+        if let Some(exposed_ports) = config.exposed_ports() {
+            annotations.insert(
+                ANNOTATION_EXPOSED_PORTS.to_string(),
+                exposed_ports.join(","),
+            );
+        }
+
+        // Implementations SHOULD provide mounts for these locations such that application data is
+        // not written to the container's root filesystem. If a converter implements conversion for
+        // this field using mountpoints, it SHOULD set the destination of the mountpoint to the
+        // value specified in Config.Volumes. An implementation MAY seed the contents of the mount
+        // with data in the image at the same location. If a new image is created from a container
+        // based on the image described by this configuration, data in these paths SHOULD NOT be
+        // included in the new image. The other mounts fields are platform and context dependent,
+        // and thus are implementation-defined.
+        //
+        // Note that the implementation of Config.Volumes need not use mountpoints, as it is
+        // effectively a mask of the filesystem.
         if let Some(volumes) = config.volumes() {
+            let mut mounts: Vec<Mount> = vec![];
             for v in volumes.iter() {
                 let mut m = Mount::default();
                 m.set_destination(PathBuf::from(v))
@@ -88,23 +147,12 @@ pub fn create_runtime_config(
                     ]));
                 mounts.push(m.clone());
             }
-        }
-
-        if !mounts.is_empty() {
-            if let Some(default_mounts) = spec.mounts() {
-                mounts.extend(default_mounts.clone());
+            if !mounts.is_empty() {
+                if let Some(default_mounts) = spec.mounts() {
+                    mounts.extend(default_mounts.clone());
+                }
+                spec.set_mounts(Some(mounts));
             }
-            spec.set_mounts(Some(mounts));
-        }
-
-        if let Some(stop_signal) = config.stop_signal() {
-            annotations.insert(ANNOTATION_STOP_SIGNAL.to_string(), stop_signal.to_string());
-        }
-        if let Some(exposed_ports) = config.exposed_ports() {
-            annotations.insert(
-                ANNOTATION_EXPOSED_PORTS.to_string(),
-                exposed_ports.join(","),
-            );
         }
     }
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -35,22 +35,11 @@ pub fn create_runtime_config(
     bundle_path: &Path,
 ) -> Result<PathBuf> {
     let mut spec = Spec::default();
-
-    // Update the default hostname of `youki`
-    spec.set_hostname(Some(BUNDLE_HOSTNAME.to_string()));
-
     let mut annotations: HashMap<String, String> = HashMap::new();
-    annotations.insert(ANNOTATION_OS.to_string(), image_config.os().to_string());
-    annotations.insert(
-        ANNOTATION_ARCH.to_string(),
-        image_config.architecture().to_string(),
-    );
-    if let Some(author) = image_config.author() {
-        annotations.insert(ANNOTATION_AUTHOR.to_string(), author.to_string());
-    }
-    if let Some(created) = image_config.created() {
-        annotations.insert(ANNOTATION_CREATED.to_string(), created.to_string());
-    }
+    let mut labels = HashMap::new();
+
+    // Update the default hostname
+    spec.set_hostname(Some(BUNDLE_HOSTNAME.to_string()));
 
     if let Some(config) = image_config.config() {
         let mut process = Process::default();
@@ -84,13 +73,31 @@ pub fn create_runtime_config(
         if !args.is_empty() {
             process.set_args(Some(args));
         }
+        spec.set_process(Some(process));
 
-        // Annotation Fields
-        if let Some(labels) = config.labels() {
-            annotations.extend(labels.clone());
+        // Annotation Fields:
+        //
+        // These fields all affect the annotations of the runtime configuration, and are thus
+        // subject to precedence: if there is a conflict (same key but different value) between an
+        // implicit annotation and an explicitly specified annotation in Config.Labels, the value
+        // specified in Config.Labels MUST take precedence.
+        // - os: org.opencontainers.image.os
+        // - os.version: org.opencontainers.image.os.version
+        // - os.features: org.opencontainers.image.os.features
+        // - architecture: org.opencontainers.image.architecture
+        // - variant: org.opencontainers.image.variant
+        // - author: org.opencontainers.image.author
+        // - created: org.opencontainers.image.created
+        // - Config.StopSignal: org.opencontainers.image.stopSignal
+        // - Config.Labels
+        if let Some(labels2) = config.labels() {
+            annotations.extend(labels2.clone());
+            labels = labels2.clone();
         }
-        if let Some(stop_signal) = config.stop_signal() {
-            annotations.insert(ANNOTATION_STOP_SIGNAL.to_string(), stop_signal.to_string());
+        if !labels.contains_key(ANNOTATION_STOP_SIGNAL) {
+            if let Some(stop_signal) = config.stop_signal() {
+                annotations.insert(ANNOTATION_STOP_SIGNAL.to_string(), stop_signal.to_string());
+            }
         }
 
         // Parsed Fields:
@@ -153,6 +160,26 @@ pub fn create_runtime_config(
                 }
                 spec.set_mounts(Some(mounts));
             }
+        }
+    }
+
+    if !labels.contains_key(ANNOTATION_OS) {
+        annotations.insert(ANNOTATION_OS.to_string(), image_config.os().to_string());
+    }
+    if !labels.contains_key(ANNOTATION_ARCH) {
+        annotations.insert(
+            ANNOTATION_ARCH.to_string(),
+            image_config.architecture().to_string(),
+        );
+    }
+    if !labels.contains_key(ANNOTATION_AUTHOR) {
+        if let Some(author) = image_config.author() {
+            annotations.insert(ANNOTATION_AUTHOR.to_string(), author.to_string());
+        }
+    }
+    if !labels.contains_key(ANNOTATION_CREATED) {
+        if let Some(created) = image_config.created() {
+            annotations.insert(ANNOTATION_CREATED.to_string(), created.to_string());
         }
     }
 


### PR DESCRIPTION
Refine create_runtime_config() by:
1) add more comments
2) fix error in generating annotations
3) add support for missed annotations