### PR TITLE
[Signature] Solve the compiling problem integrated with kata-agent

### DIFF
--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1.0"
 base64 = "0.13.0"
-sequoia-openpgp = "1.7.0"
+sequoia-openpgp = { version = "1.7.0", default-features = false, features = ["compression", "crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto"] }

--- a/signature/src/policy/mod.rs
+++ b/signature/src/policy/mod.rs
@@ -39,7 +39,7 @@ pub struct Policy {
     transports: HashMap<String, PolicyTransportScopes>,
 }
 
-pub type PolicyRequirements = Vec<Box<dyn PolicyRequirement>>;
+pub type PolicyRequirements = Vec<Box<dyn PolicyRequirement + Send>>;
 pub type PolicyTransportScopes = HashMap<String, PolicyRequirements>;
 
 impl Policy {


### PR DESCRIPTION
Due to some special dependencies and implementations of the signature module,
musl compilation fails when integrating with Kata-agent. This commit solves these problems.

cc @arronwy 