### PR TITLE
Pin a specific version of ocicrypt-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2"
 nix = "0.23.0"
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "1ba0d94a900a97aa1bcac032a67ea23766bcfdef" }
 oci-spec = { git = "https://github.com/containers/oci-spec-rs" }
-ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs" }
+ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", rev = "251ed40822f4d243a59bdd395cccdcbae2bca2be" }
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
 sha2 = ">=0.10"

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -10,7 +10,7 @@ use zstd;
 
 /// Represents the layer compression algorithm type,
 /// and allows to decompress corresponding compressed data.
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
 pub enum Compression {
     Uncompressed,
     Gzip,

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -107,6 +107,6 @@ fn decrypt_layer_data(
 
         Ok(plaintext_data)
     } else {
-        return Err(anyhow!("no decrypt config available"));
+        Err(anyhow!("no decrypt config available"))
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -180,6 +180,6 @@ async fn get_resource_from_kbs(resource_name: &str, aa_kbc_params: &str) -> Resu
 
         Ok(res.into_inner().resource)
     } else {
-        return Err(anyhow!("aa_kbc_params: KBC/KBS pair not found"));
+        Err(anyhow!("aa_kbc_params: KBC/KBS pair not found"))
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -33,7 +33,7 @@ mod get_resource {
     tonic::include_proto!("getresource");
 }
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+#[derive(EnumString, Display, Debug, PartialEq, Eq)]
 pub enum SimpleSigning {
     #[strum(to_string = "/run/image-security/simple_signing")]
     ConfigDir,

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -28,6 +28,8 @@ const IMAGE_SECURITY_CONFIG_DIR: &str = "/run/image-security";
 const POLICY_FILE_PATH: &str = "/run/image-security/security_policy.json";
 
 mod get_resource {
+    #![allow(unknown_lints)]
+    #![allow(clippy::derive_partial_eq_without_eq)]
     tonic::include_proto!("getresource");
 }
 


### PR DESCRIPTION
Instead of using ocicrypt-rs from `main`, let's pin a specific version,
which is known to be working, and move to newer commits as it becomes
required / desired, instead of keep following ocicrypt-rs' main.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>