### PR TITLE
Modularization on signature verification schemes

### DIFF
--- a/signature/README.md
+++ b/signature/README.md
@@ -110,4 +110,4 @@ implemented in step 1.
 
 |Sign Scheme|Readme|
 |---|---|
-|[Simple Signing](src/mechanism/simple)| - |
+|[Simple Signing](src/mechanism/simple)| [README](src/mechanism/simple/README.md) |

--- a/signature/README.md
+++ b/signature/README.md
@@ -1,0 +1,113 @@
+# Signature Module for Image-rs
+
+This is the signature module for image-rs. In fact, signature verification
+is included in the policy processing.
+
+## How is signature verification working?
+
+Up to now, all signature verification in image-rs happens due to
+the image security [policy](https://github.com/confidential-containers/image-rs/blob/main/docs/ccv1_image_security_design.md#policy) 
+file.
+
+The format of policy file is detailed [here](../docs/ccv1_image_security_design.md#policy).
+
+Each signing scheme works due to the `scheme` field in a [Policy Requirement](https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#policy-requirements).
+
+The format of a Policy Requirement may be little different from the mentioned link.
+
+A Policy Requirement claiming a specific signature scheme in the `scheme` field.
+Here are some examples for [Simple Signing](src/mechanism/simple/README.md)
+
+```json
+{
+    "type": "signedBy",
+    "scheme": "simple",
+    "keyType": "GPGKeys",
+    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+}
+```
+
+Here, the `type` field here must be `signedBy` if this Policy Requirement
+requires signature verification. And the `scheme` field will indicate
+the concrete signing scheme for this Policy Requirement. The rest of the 
+fields may be different due to different signing scheme. 
+
+For example,
+[Simple Signing](src/mechanism/simple/README.md) here requires fields
+`keyType`, `keyPath`, `keyData`, and `signedIdentity`.
+
+## How to add new Signing Scheme?
+
+For example, a new scheme called `new-sign-scheme` is to be added.
+Here are the positions must be modified.
+
+1. `src/mechanism/new-sign-scheme` directory
+Create `src/mechanism/new-sign-scheme/mod.rs`
+
+Add `pub mod new_sign_scheme` into  `src/mechanism/mod.rs`
+
+In `src/mechanism/new-sign-scheme/mod.rs`, define the unique parameters 
+used in the `policy.json` by `new-sign-scheme`.
+For example, a field named `signature-path` should be included, like
+
+```json
+// ... A Policy Requirement
+{
+    "type": "signedBy",
+    "scheme": "new-sign-scheme",
+    "signature-path": "/keys/123.key",
+}
+```
+
+Then the parameters' struct can be defined in `src/mechanism/new-sign-scheme/mod.rs`,
+like this
+
+```rust
+#[derive(Deserialize, Debug, PartialEq, Serialize)]
+pub struct NewSignSchemeParameters {
+    #[serde(rename = "signature-path")]
+    pub signature_path: String,
+}
+```
+And then the field can be deserialized from `policy.json`.
+
+Besides, Implement the public function `some_verify_function()`. This is the core
+function for `new-sign-scheme` to verify signatures.
+
+2. `src/mechanism/mod.rs`.
+
+Add a new enum value `NewSignScheme` for `SignScheme` in 
+
+```rust
+pub enum SignScheme {
+    #[serde(rename = "simple")]
+    SimpleSigning(SimpleParameters),
+    // Here new scheme
+    #[serde(rename = "new-sign-scheme")]
+    NewSignScheme(NewSignSchemeParameters),
+}
+```
+
+Fill in the new arm in the following function. 
+```rust
+pub fn allows_image(&self, image: &mut Image) -> Result<()> {
+        match self {
+            SignScheme::SimpleSigning(parameters) => {
+                simple::judge_signatures_accept(&parameters, image)
+            }
+            // New arm
+            SignScheme::NewSignScheme(parameters) => {
+                new_sign_scheme::some_verify_function(&parameters, image)
+            }
+        }
+    }
+```
+
+Here, `some_verify_function` is the signature's verifier function
+implemented in step 1.
+
+## Supported Signatures
+
+|Sign Scheme|Readme|
+|---|---|
+|[Simple Signing](src/mechanism/simple)| - |

--- a/signature/src/image/mod.rs
+++ b/signature/src/image/mod.rs
@@ -3,11 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::mechanism;
-use crate::SignatureScheme;
-use anyhow::{anyhow, Result};
+use anyhow::*;
 use oci_distribution::Reference;
-use std::str::FromStr;
 
 pub mod digest;
 
@@ -47,20 +44,6 @@ impl Image {
     pub fn set_manifest_digest(&mut self, digest: &str) -> Result<()> {
         self.manifest_digest = Digest::try_from(digest)?;
         Ok(())
-    }
-
-    pub fn signatures(&mut self, scheme: &str) -> Result<Vec<Vec<u8>>> {
-        match crate::SignatureScheme::from_str(scheme) {
-            Ok(SignatureScheme::SimpleSigning) => {
-                return Ok(mechanism::simple::get_signatures(self)?);
-            }
-            // TODO: Add more signature mechanism.
-            //
-            // Refer to issue: https://github.com/confidential-containers/image-rs/issues/7
-            _ => {
-                return Err(anyhow!(crate::policy::ErrorInfo::ErrUnknownScheme));
-            }
-        }
     }
 }
 

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -3,6 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+//! # Overall
+//! For signature verification in Confidential-Containers.
+//!
+//! # Interfaces
+//! #### Image
+//! An image struct is a well-encapsulated struct used to do
+//! image verification.
+//!
+//! #### Policy
+//! A `Policy` is a policy used to verify the image, usually
+//! including signing scheme of the image, or some other rules.
+//! 
+//! #### SignScheme
+//! Sign Scheme for the given signature.
+
 #[macro_use]
 extern crate strum;
 
@@ -12,9 +27,4 @@ mod policy;
 
 pub use image::Image;
 pub use policy::Policy;
-
-#[derive(EnumString, Display, Debug, PartialEq)]
-pub enum SignatureScheme {
-    #[strum(serialize = "simple")]
-    SimpleSigning,
-}
+pub use mechanism::SignScheme;

--- a/signature/src/mechanism/mod.rs
+++ b/signature/src/mechanism/mod.rs
@@ -3,4 +3,34 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use serde::{Deserialize, Serialize};
+use anyhow::*;
+
+use crate::Image;
+
+use self::simple::SimpleParameters;
+
 pub mod simple;
+
+/// Signing schemes.
+/// * `SimpleSigning`: Redhat simple signing.
+#[derive(Deserialize, Debug, PartialEq, Serialize)]
+#[serde(tag = "scheme")]
+pub enum SignScheme {
+    #[serde(rename = "simple")]
+    SimpleSigning(SimpleParameters),
+}
+
+// TODO: Add more signature mechanism.
+//
+// Refer to issue: https://github.com/confidential-containers/image-rs/issues/7
+
+impl SignScheme {
+    pub fn allows_image(&self, image: &mut Image) -> Result<()> {
+        match self {
+            SignScheme::SimpleSigning(parameters) => {
+                simple::judge_signatures_accept(&parameters, image)
+            }
+        }
+    }
+}

--- a/signature/src/mechanism/simple/README.md
+++ b/signature/src/mechanism/simple/README.md
@@ -1,0 +1,32 @@
+# Simple Signing
+
+Simple Signing is the first signature that CC supports. Refer to 
+[CCv1 Image Security Design](../../../../docs/ccv1_image_security_design.md#image-signing).
+
+## Policy Format
+
+Simple Signing is verified due to the container's policy configuration file.
+
+A Policy Requirement of Simple Signing should be like this
+
+```json
+{
+    "type": "signedBy",
+    "scheme": "simple",
+    "keyType": "<KEY-TYPE>",
+    "keyData": "<PUBKEY-DATA-IN-BASE64>",
+    "keyPath": "<PATH-TO-THE-PUBKEY>",
+    "signedIdentity": <JSON-OBJECT>,
+},
+```
+
+Here, 
+* The `type` field must be `signedBy`, showing that this Policy Requirement
+needs a signature verification.
+* The `scheme` field must be `simple`, showing this signature is Simple Signing.
+* The `keyType` field indicates the pubkey's type. Now only `GPGKeys` is supported.
+* The `keyData` field includes the pubkey's content in base64.
+* The `keyPath` field indicates the pubkey's path. 
+* `signedIdentity` includes a JSON object, refer to [signedIdentity](https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#signedby) for detail.
+
+**WARNING**: Must specify either `keyData` or `keyPath`, and must not both.

--- a/signature/src/policy/policy_requirement.rs
+++ b/signature/src/policy/policy_requirement.rs
@@ -4,199 +4,181 @@
 //
 
 use anyhow::{anyhow, Result};
-use serde::de::{self, MapAccess, Visitor};
 use serde::*;
-use serde_json::{Map, Value};
-use std::convert::TryFrom;
-use std::str::FromStr;
 
-use crate::image;
-use crate::mechanism;
+use crate::SignScheme;
+use crate::Image;
 
-use crate::policy::ref_match::PolicyReferenceMatcher;
-use crate::policy::ErrorInfo;
-use crate::SignatureScheme;
-
-#[derive(EnumString, Display, Debug, PartialEq)]
+/// Policy Requirement Types.
+/// * `Accept`: s.t. `insecureAcceptAnything`, skip signature verification, accept the image unconditionally.
+/// * `Reject`: s.t. `reject`, reject the image directly.
+/// * `SignedBy`: s.t. `signBy`, means that the image is signed by some signing scheme.
+/// The member of `SignedBy` here is another enum `SignScheme`. Because each
+/// sign scheme may have different json fields in the `policy.json`. So if any
+/// new scheme is being added, a new `SignScheme` enum entry should be added, too.
+#[derive(Deserialize, Debug, PartialEq, Serialize)]
+#[serde(tag = "type")]
 pub enum PolicyReqType {
-    #[strum(to_string = "insecureAcceptAnything")]
-    TypeAccept,
-    #[strum(to_string = "reject")]
-    TypeReject,
-    #[strum(to_string = "signedBy")]
-    TypeSignedBy,
+    #[serde(rename = "insecureAcceptAnything")]
+    Accept,
+    #[serde(rename = "reject")]
+    Reject,
+    #[serde(rename = "signedBy")]
+    SignedBy(SignScheme),
 }
 
-// Policy requirement is a rule which must be satisfied by the image.
-// It has three types:
-//   `insecureAcceptAnything`: skip signature verification, accept the image unconditionally.
-//   `reject`: reject the image directly.
-//   `signedBy`: there must be at least a signature of the image can be verified by the specific key.
-pub trait PolicyRequirement {
-    fn is_image_allowed(&self, image: &mut image::Image) -> Result<()>;
-    fn signature_scheme(&self) -> Option<String> {
-        None
-    }
-}
-
-impl<'de> Deserialize<'de> for Box<dyn PolicyRequirement + Send> {
-    fn deserialize<D>(deserializer: D) -> Result<Box<dyn PolicyRequirement + Send>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(PolicyRequirementVisitor)
-    }
-}
-
-struct PolicyRequirementVisitor;
-
-impl<'de> Visitor<'de> for PolicyRequirementVisitor {
-    type Value = Box<dyn PolicyRequirement + Send>;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("Unexpect policy requirement deserialize visit format")
-    }
-
-    #[allow(unused_assignments)]
-    fn visit_map<A>(self, mut json_map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut map = Map::new();
-        loop {
-            if let Result::Ok(Some(entry)) = json_map.next_entry::<String, Value>() {
-                map.insert(entry.0.into(), entry.1.into());
-            } else {
-                break;
-            }
-        }
-
-        let v: Value = map.into();
-        let json_str = serde_json::to_string(&v).map_err(de::Error::custom)?;
-
-        let mut r#type = String::new();
-        if let Value::String(s) = &v["type"] {
-            r#type = s.to_string();
-        } else {
-            return Err(de::Error::custom(
-                &ErrorInfo::ErrUnknownMatchPolicyType.to_string(),
-            ));
-        }
-
-        match PolicyReqType::from_str(&r#type) {
-            Ok(PolicyReqType::TypeAccept) => {
-                let res: PolicyReqAccept =
-                    serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            Ok(PolicyReqType::TypeReject) => {
-                let res: PolicyReqReject =
-                    serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            Ok(PolicyReqType::TypeSignedBy) => {
-                let res: PolicyReqSignedBy =
-                    serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            _ => {
-                return Err(de::Error::custom(
-                    &ErrorInfo::ErrUnknowPolicyReqType.to_string(),
-                ));
-            }
+impl PolicyReqType {
+    /// Check whether an image is allowed by a given policy requirement.
+    pub fn allows_image(&self, image: &mut Image) -> Result<()> {
+        match self {
+            PolicyReqType::Accept => Ok(()),
+            PolicyReqType::Reject => Err(anyhow!(r#"The policy is "reject""#)),
+            PolicyReqType::SignedBy(scheme) => scheme.allows_image(image),
         }
     }
 }
 
-impl TryFrom<&str> for Box<dyn PolicyRequirement + Send> {
-    type Error = serde_json::Error;
-    fn try_from(json_str: &str) -> Result<Self, Self::Error> {
-        serde_json::from_str::<Box<dyn PolicyRequirement + Send>>(json_str)
+
+#[cfg(test)]
+mod tests {
+    use crate::{policy::{PolicyReqType, policy_requirement::SignScheme, ref_match::PolicyReqMatchType}, mechanism::simple::SimpleParameters};
+
+    #[test]
+    fn deserialize_accept_policy() {
+        let json = r#"{
+            "type": "insecureAcceptAnything"
+        }"#;
+        let policy_parsed: PolicyReqType = serde_json::from_str(json).unwrap();
+        let policy = PolicyReqType::Accept;
+        assert_eq!(policy, policy_parsed);
     }
-}
 
-// The `insecureAcceptAnything` policy requirement.
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct PolicyReqAccept {
-    r#type: String,
-}
-
-unsafe impl Send for PolicyReqAccept {}
-
-impl PolicyRequirement for PolicyReqAccept {
-    fn is_image_allowed(&self, _image: &mut image::Image) -> Result<()> {
-        Ok(())
+    #[test]
+    fn deserialize_reject_policy() {
+        let json = r#"{
+            "type": "reject"
+        }"#;
+        let policy_parsed: PolicyReqType = serde_json::from_str(json).unwrap();
+        let policy = PolicyReqType::Reject;
+        assert_eq!(policy, policy_parsed);
     }
-}
 
-// The `insecureAcceptAnything` policy requirement.
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct PolicyReqReject {
-    r#type: String,
-}
+    #[test]
+    fn deserialize_signed_by_policy() {
+        let jsons = [
+            r#"{
+                "type": "signedBy",
+                "scheme": "simple",
+                "keyType": "GPGKeys",
+                "keyPath": "/keys/public-gpg-keyring"
+            }"#,
+            r#"{
+                "type": "signedBy",
+                "scheme": "simple",
+                "keyType": "GPGKeys",
+                "keyData": "bm9uc2Vuc2U="
+            }"#,
+            r#"{
+                "type": "signedBy",
+                "scheme": "simple",
+                "keyType": "GPGKeys",
+                "keyPath": "/keys/public-gpg-keyring",
+                "signedIdentity": {
+                    "type": "matchExact"
+                }
+            }"#,
+            r#"{
+                "type": "signedBy",
+                "scheme": "simple",
+                "keyType": "GPGKeys",
+                "keyPath": "/keys/public-gpg-keyring",
+                "signedIdentity": {
+                    "type": "exactReference",
+                    "dockerReference": "docker.io/example/busybox:latest"
+                }
+            }"#,
+            r#"{
+                "type": "signedBy",
+                "scheme": "simple",
+                "keyType": "GPGKeys",
+                "keyPath": "/keys/public-gpg-keyring",
+                "signedIdentity": {
+                    "type": "remapIdentity",
+                    "prefix": "example",
+                    "signedPrefix": "example"
+                }
+            }"#,
+        ];
+        let policies = [
+            PolicyReqType::SignedBy(
+                SignScheme::SimpleSigning(
+                    SimpleParameters {
+                        key_type: "GPGKeys".into(),
+                        key_path: Some("/keys/public-gpg-keyring".into()),
+                        key_data: None,
+                        signed_identity: None,
+                    }
+                )
+            ),
+            PolicyReqType::SignedBy(
+                SignScheme::SimpleSigning(
+                    SimpleParameters {
+                        key_type: "GPGKeys".into(),
+                        key_path: None,
+                        key_data: Some("bm9uc2Vuc2U=".into()),
+                        signed_identity: None,
+                    }
+                )
+            ),
+            PolicyReqType::SignedBy(
+                SignScheme::SimpleSigning(
+                    SimpleParameters {
+                        key_type: "GPGKeys".into(),
+                        key_path: Some("/keys/public-gpg-keyring".into()),
+                        key_data: None,
+                        signed_identity: Some(PolicyReqMatchType::MatchExact),
+                    }
+                )
+            ),
+            PolicyReqType::SignedBy(
+                SignScheme::SimpleSigning(
+                    SimpleParameters {
+                        key_type: "GPGKeys".into(),
+                        key_path: Some("/keys/public-gpg-keyring".into()),
+                        key_data: None,
+                        signed_identity: Some(
+                            PolicyReqMatchType::ExactReference {
+                                docker_reference: "docker.io/example/busybox:latest".into(),
+                            }
+                        ),
+                    }
+                )
+            ),
+            PolicyReqType::SignedBy(
+                SignScheme::SimpleSigning(
+                    SimpleParameters {
+                        key_type: "GPGKeys".into(),
+                        key_path: Some("/keys/public-gpg-keyring".into()),
+                        key_data: None,
+                        signed_identity: Some(
+                            PolicyReqMatchType::RemapIdentity {
+                                prefix: "example".into(),
+                                signed_prefix: "example".into(),
+                            }
+                        ),
+                    }
+                )
+            ),
+        ];
 
-unsafe impl Send for PolicyReqReject {}
-
-impl PolicyRequirement for PolicyReqReject {
-    fn is_image_allowed(&self, _image: &mut image::Image) -> Result<()> {
-        Err(anyhow!(r#"The policy is "reject""#))
-    }
-}
-
-// The `signedBy` policy requirement:
-// The image must be signed by trusted keys for a specified identity
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct PolicyReqSignedBy {
-    r#type: String,
-
-    // scheme specifies the scheme used to verify the signature.
-    // This field is the basis for selecting an appropriate mechanism for signature verification.
-    pub scheme: String,
-
-    // KeyType specifies what kind of the public key to verify the signatures.
-    #[serde(rename = "keyType")]
-    pub key_type: String,
-
-    // KeyPath is a pathname to a local file containing the trusted key(s).
-    // Exactly one of KeyPath and KeyData can be specified.
-    //
-    // This field is optional.
-    #[serde(default, rename = "keyPath")]
-    pub key_path: String,
-    // KeyData contains the trusted key(s), base64-encoded.
-    // Exactly one of KeyPath and KeyData can be specified.
-    //
-    // This field is optional.
-    #[serde(default, rename = "keyData")]
-    pub key_data: String,
-
-    // SignedIdentity specifies what image identity the signature must be claiming about the image.
-    // Defaults to "match-exact" if not specified.
-    //
-    // This field is optional.
-    #[serde(default, rename = "signedIdentity")]
-    pub signed_identity: Option<Box<dyn PolicyReferenceMatcher>>,
-}
-
-unsafe impl Send for PolicyReqSignedBy {}
-
-impl PolicyRequirement for PolicyReqSignedBy {
-    fn is_image_allowed(&self, image: &mut image::Image) -> Result<()> {
-        match SignatureScheme::from_str(&self.scheme) {
-            Ok(SignatureScheme::SimpleSigning) => {
-                return mechanism::simple::judge_signatures_accept(self.clone(), image);
-            }
-            // TODO: Add more signature mechanism.
-            //
-            // Refer to issue: https://github.com/confidential-containers/image-rs/issues/7
-            _ => Err(anyhow!(ErrorInfo::ErrUnknownScheme.to_string())),
+        let policy_parsed: Vec<PolicyReqType> = jsons.iter()
+            .map(|json|{
+                serde_json::from_str(json).unwrap()
+            })
+            .collect();
+        
+        for i in 0..jsons.len() {
+            assert_eq!(policies[i], policy_parsed[i]);
         }
-    }
-
-    fn signature_scheme(&self) -> Option<String> {
-        Some(self.scheme.clone())
     }
 }

--- a/signature/src/policy/ref_match.rs
+++ b/signature/src/policy/ref_match.rs
@@ -5,298 +5,159 @@
 
 use anyhow::{anyhow, Result};
 use oci_distribution::Reference;
-use serde::de::{self, MapAccess, Visitor};
 use serde::*;
-use serde_json::{Map, Value};
 use std::convert::TryFrom;
-use std::str::FromStr;
 
 use crate::image;
-
 use crate::policy::ErrorInfo;
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+/// The `signedIdentity` field in simple signing. It is a JSON object, specifying what image
+/// identity the signature claims about the image.
+#[derive(Deserialize, Display, Debug, PartialEq, Serialize)]
+#[serde(tag = "type")]
 pub enum PolicyReqMatchType {
-    #[strum(serialize = "matchExact")]
-    TypeMatchExact,
-    #[strum(serialize = "matchRepoDigestOrExact")]
-    TypeMatchRepoDigestOrExact,
-    #[strum(serialize = "matchRepository")]
-    TypeMatchRepository,
-    #[strum(serialize = "exactReference")]
-    TypeExactReference,
-    #[strum(serialize = "exactRepository")]
-    TypeExactRepository,
-    #[strum(serialize = "remapIdentity")]
-    TypeRemapIdentity,
+    /// `matchExact` match type : the two references must match exactly.
+    #[serde(rename = "matchExact")]
+    MatchExact,
+
+    /// `matchRepoDigestOrExact` match type: the two references must match exactly,
+    /// except that digest references are also accepted
+    /// if the repository name matches (regardless of tag/digest)
+    /// and the signature applies to the referenced digest.
+    #[serde(rename = "matchRepoDigestOrExact")]
+    MatchRepoDigestOrExact,
+
+    /// `matchRepository` match type: the two references must use the same repository, may differ in the tag.
+    #[serde(rename = "matchRepository")]
+    MatchRepository,
+
+    /// `exactReference` match type: matches a specified reference exactly.
+    #[serde(rename = "exactReference")]
+    ExactReference {
+        #[serde(rename = "dockerReference")]
+        docker_reference: String,
+    },
+
+    /// `exactRepository` match type: matches a specified repository, with any tag.
+    #[serde(rename = "exactRepository")]
+    ExactRepository {
+        #[serde(rename = "dockerRepository")]
+        docker_repository: String,
+    },
+
+    /// `remapIdentity` match type:
+    /// except that a namespace (at least a host:port, at most a single repository)
+    /// is substituted before matching the two references.
+    #[serde(rename = "remapIdentity")]
+    RemapIdentity {
+        prefix: String,
+        #[serde(rename = "signedPrefix")]
+        signed_prefix: String,
+    },
 }
 
 // PolicyReferenceMatch specifies a set of image identities(image-reference) accepted in PolicyRequirement.
-pub trait PolicyReferenceMatcher {
-    fn matches_docker_reference(&self, origin: &Reference, signed_image_ref: &str) -> Result<()>;
-}
-
-impl<'de> Deserialize<'de> for Box<dyn PolicyReferenceMatcher> {
-    fn deserialize<D>(deserializer: D) -> Result<Box<dyn PolicyReferenceMatcher>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(PolicyReferenceMatcherVisitor)
-    }
-}
-
-struct PolicyReferenceMatcherVisitor;
-
-impl<'de> Visitor<'de> for PolicyReferenceMatcherVisitor {
-    type Value = Box<dyn PolicyReferenceMatcher>;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("Unexpect policy requirement deserialize visit format")
+impl PolicyReqMatchType {
+    /// Return a default match policy
+    pub fn default_match_policy() -> PolicyReqMatchType {
+        PolicyReqMatchType::MatchExact
     }
 
-    #[allow(unused_assignments)]
-    fn visit_map<A>(self, mut json_map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut map = Map::new();
-        loop {
-            if let Result::Ok(Some(entry)) = json_map.next_entry::<String, Value>() {
-                map.insert(entry.0.into(), entry.1.into());
-            } else {
-                break;
-            }
-        }
-
-        let v: Value = map.into();
-        let json_str = serde_json::to_string(&v).map_err(de::Error::custom)?;
-
-        let mut r#type = String::new();
-        if let Value::String(s) = &v["type"] {
-            r#type = s.to_string();
-        } else {
-            return Err(de::Error::custom(
-                &ErrorInfo::ErrUnknownMatchPolicyType.to_string(),
-            ));
-        }
-
-        match PolicyReqMatchType::from_str(&r#type) {
-            Ok(PolicyReqMatchType::TypeMatchExact) => {
-                let res: MatchExact = serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            Ok(PolicyReqMatchType::TypeMatchRepoDigestOrExact) => {
-                let res: MatchRepoDigestOrExact =
-                    serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            Ok(PolicyReqMatchType::TypeMatchRepository) => {
-                let res: MatchRepository =
-                    serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            Ok(PolicyReqMatchType::TypeExactReference) => {
-                let res: MatchExactReference =
-                    serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            Ok(PolicyReqMatchType::TypeExactRepository) => {
-                let res: MatchExactRepository =
-                    serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            Ok(PolicyReqMatchType::TypeRemapIdentity) => {
-                let res: MatchRemapIdentity =
-                    serde_json::from_str(&json_str).map_err(de::Error::custom)?;
-                return Ok(Box::new(res));
-            }
-            _ => {
-                return Err(de::Error::custom(
-                    &ErrorInfo::ErrUnknownMatchPolicyType.to_string(),
-                ));
-            }
-        }
-    }
-}
-
-impl TryFrom<&str> for Box<dyn PolicyReferenceMatcher> {
-    type Error = serde_json::Error;
-    fn try_from(json_str: &str) -> Result<Self, Self::Error> {
-        serde_json::from_str::<Box<dyn PolicyReferenceMatcher>>(json_str)
-    }
-}
-
-// "matchExact" match type : the two references must match exactly.
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct MatchExact {
-    r#type: String,
-}
-
-impl PolicyReferenceMatcher for MatchExact {
-    fn matches_docker_reference(&self, origin: &Reference, signed_image_ref: &str) -> Result<()> {
-        if origin.digest().is_some() {
-            return Err(anyhow!(
-                "Can not reference the image with the digest in {} policy.",
-                PolicyReqMatchType::TypeMatchExact.to_string()
-            ));
-        }
-        if origin.whole() != *signed_image_ref {
-            return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
-        }
-        Ok(())
-    }
-}
-
-// "matchRepoDigestOrExact" match type: the two references must match exactly,
-// except that digest references are also accepted
-// if the repository name matches (regardless of tag/digest)
-// and the signature applies to the referenced digest.
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct MatchRepoDigestOrExact {
-    r#type: String,
-}
-
-impl PolicyReferenceMatcher for MatchRepoDigestOrExact {
-    fn matches_docker_reference(&self, origin: &Reference, signed_image_ref: &str) -> Result<()> {
-        if origin.tag().is_some() && origin.whole() != *signed_image_ref {
-            return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
-        }
-        if origin.digest().is_some()
-            && image::get_image_repository_full_name(origin)
-                != image::get_image_repository_full_name(&Reference::try_from(signed_image_ref)?)
-        {
-            return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
-        }
-        Ok(())
-    }
-}
-
-// "matchRepository" match type: the two references must use the same repository, may differ in the tag.
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct MatchRepository {
-    r#type: String,
-}
-
-impl PolicyReferenceMatcher for MatchRepository {
-    fn matches_docker_reference(&self, origin: &Reference, signed_image_ref: &str) -> Result<()> {
-        if image::get_image_repository_full_name(origin)
-            != image::get_image_repository_full_name(&Reference::try_from(signed_image_ref)?)
-        {
-            return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
-        }
-        Ok(())
-    }
-}
-
-// Match type: "exactReference".
-// matches a specified reference exactly.
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct MatchExactReference {
-    r#type: String,
-    #[serde(rename = "dockerReference")]
-    docker_reference: String,
-}
-
-impl PolicyReferenceMatcher for MatchExactReference {
-    fn matches_docker_reference(
+    /// Check whether matches reference
+    pub fn matches_docker_reference(
         &self,
-        _origin_ref: &Reference,
+        origin: &Reference,
         signed_image_ref: &str,
     ) -> Result<()> {
-        if *signed_image_ref != self.docker_reference {
-            return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+        match self {
+            PolicyReqMatchType::MatchExact => {
+                if origin.digest().is_some() {
+                    return Err(anyhow!(
+                        "Can not reference the image with the digest in matchExact policy.",
+                    ));
+                }
+                if origin.whole() != *signed_image_ref {
+                    return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+                }
+            }
+            PolicyReqMatchType::MatchRepoDigestOrExact => {
+                if origin.tag().is_some() && origin.whole() != *signed_image_ref {
+                    return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+                }
+                if origin.digest().is_some()
+                    && image::get_image_repository_full_name(origin)
+                        != image::get_image_repository_full_name(&Reference::try_from(
+                            signed_image_ref,
+                        )?)
+                {
+                    return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+                }
+            }
+            PolicyReqMatchType::MatchRepository => {
+                if image::get_image_repository_full_name(origin)
+                    != image::get_image_repository_full_name(&Reference::try_from(
+                        signed_image_ref,
+                    )?)
+                {
+                    return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+                }
+            }
+            PolicyReqMatchType::ExactReference { docker_reference } => {
+                if signed_image_ref != docker_reference {
+                    return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+                }
+            }
+            PolicyReqMatchType::ExactRepository { docker_repository } => {
+                if image::get_image_repository_full_name(&Reference::try_from(signed_image_ref)?)
+                    != *docker_repository
+                {
+                    return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+                }
+            }
+            PolicyReqMatchType::RemapIdentity {
+                prefix,
+                signed_prefix,
+            } => {
+                let mut origin_ref_string = origin.whole();
+
+                if let Some(ref_with_no_prefix) = origin_ref_string.strip_prefix(prefix) {
+                    origin_ref_string = format!("{}{}", signed_prefix, ref_with_no_prefix);
+                }
+
+                let new_origin_ref = Reference::try_from(origin_ref_string.as_str())?;
+
+                if new_origin_ref.tag().is_some() && new_origin_ref.whole() != *signed_image_ref {
+                    return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+                }
+                if new_origin_ref.digest().is_some()
+                    && image::get_image_repository_full_name(&new_origin_ref)
+                        != image::get_image_repository_full_name(&Reference::try_from(
+                            signed_image_ref,
+                        )?)
+                {
+                    return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
+                }
+            }
         }
         Ok(())
     }
-}
-
-// Match type: "exactRepository"
-// matches a specified repository, with any tag.
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct MatchExactRepository {
-    r#type: String,
-    #[serde(rename = "dockerRepository")]
-    docker_repository: String,
-}
-
-impl PolicyReferenceMatcher for MatchExactRepository {
-    fn matches_docker_reference(
-        &self,
-        _origin_ref: &Reference,
-        signed_image_ref: &str,
-    ) -> Result<()> {
-        if image::get_image_repository_full_name(&Reference::try_from(signed_image_ref)?)
-            != self.docker_repository
-        {
-            return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
-        }
-        Ok(())
-    }
-}
-
-// Match type: "remapIdentity"
-// except that a namespace (at least a host:port, at most a single repository)
-// is substituted before matching the two references.
-#[derive(Deserialize)]
-#[allow(dead_code)]
-pub struct MatchRemapIdentity {
-    r#type: String,
-    prefix: String,
-    #[serde(rename = "signedPrefix")]
-    signed_prefix: String,
-}
-
-impl PolicyReferenceMatcher for MatchRemapIdentity {
-    fn matches_docker_reference(
-        &self,
-        origin_ref: &Reference,
-        signed_image_ref: &str,
-    ) -> Result<()> {
-        let mut origin_ref_string = origin_ref.whole();
-
-        if let Some(ref_with_no_prefix) = origin_ref_string.strip_prefix(&self.prefix) {
-            origin_ref_string = format!("{}{}", &self.signed_prefix, ref_with_no_prefix);
-        }
-
-        let new_origin_ref = Reference::try_from(origin_ref_string.as_str())?;
-
-        if new_origin_ref.tag().is_some() && new_origin_ref.whole() != *signed_image_ref {
-            return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
-        }
-        if new_origin_ref.digest().is_some()
-            && image::get_image_repository_full_name(&new_origin_ref)
-                != image::get_image_repository_full_name(&Reference::try_from(signed_image_ref)?)
-        {
-            return Err(anyhow!(ErrorInfo::ErrMatchReference.to_string()));
-        }
-        Ok(())
-    }
-}
-
-pub fn default_match_policy() -> Box<dyn PolicyReferenceMatcher> {
-    Box::new(MatchExact {
-        r#type: PolicyReqMatchType::TypeMatchExact.to_string(),
-    })
 }
 
 mod tests {
+    #[allow(unused_imports)]
+    use crate::policy::ref_match::PolicyReqMatchType;
 
     #[test]
     fn test_policy_matches_docker_reference() {
         struct TestData<'a> {
-            match_policy: Box<dyn super::PolicyReferenceMatcher>,
+            match_policy: PolicyReqMatchType,
             origin_reference: oci_distribution::Reference,
             signed_reference: &'a str,
         }
 
         let tests_expect = &[
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "matchExact"
                     }"#
@@ -305,7 +166,7 @@ mod tests {
                 signed_reference: "docker.io/example/busybox:latest",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "matchRepoDigestOrExact"
                     }"#
@@ -314,7 +175,7 @@ mod tests {
                 signed_reference: "docker.io/example/busybox:latest",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "matchRepoDigestOrExact"
                     }"#
@@ -325,7 +186,7 @@ mod tests {
                 signed_reference: "docker.io/example/busybox:tag",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "matchRepository"
                     }"#
@@ -334,7 +195,7 @@ mod tests {
                 signed_reference: "docker.io/example/busybox:tag",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "exactReference",
                         "dockerReference": "docker.io/mylib/busybox:latest"
@@ -344,7 +205,7 @@ mod tests {
                 signed_reference: "docker.io/mylib/busybox:latest",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "exactRepository",
                         "dockerRepository": "docker.io/mylib/busybox"
@@ -354,7 +215,7 @@ mod tests {
                 signed_reference: "docker.io/mylib/busybox:tag",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "remapIdentity",
                         "prefix": "docker.io",
@@ -368,7 +229,7 @@ mod tests {
 
         let tests_unexpect = &[
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "matchExact"
                     }"#
@@ -377,7 +238,7 @@ mod tests {
                 signed_reference: "docker.io/example/busybox:tag",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "matchExact"
                     }"#
@@ -388,7 +249,7 @@ mod tests {
                 signed_reference: "docker.io/example/busybox@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "matchRepoDigestOrExact"
                     }"#
@@ -397,7 +258,7 @@ mod tests {
                 signed_reference: "docker.io/example/busybox:tag",
             },
             TestData {
-                match_policy: serde_json::from_str::<Box<dyn super::PolicyReferenceMatcher>>(
+                match_policy: serde_json::from_str::<PolicyReqMatchType>(
                     r#"{
                         "type": "exactReference",
                         "dockerReference": "docker.io/mylib/busybox:latest"


### PR DESCRIPTION
Thanks to discussion with @jialez0 .
As mentioned in https://github.com/confidential-containers/image-rs/issues/7, there may be three modularization to be implemented.

1. Getting signature
2. Parsing signature payload
3. Cryptography signature verification

This PR aims to deal with 3rd, including

* Some refactor for Ease of verification module development.
* Given a document to help develop new signature scheme.