### PR TITLE
ci: Update the pinned version of ocicrypt-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install nettle-sys building dependence
         run: |
-          sudo apt install clang llvm pkg-config nettle-dev
+          sudo apt install clang llvm pkg-config nettle-dev protobuf-compiler libprotobuf-dev
 
       - name: Run cargo build
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2"
 nix = "0.23.0"
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "1ba0d94a900a97aa1bcac032a67ea23766bcfdef" }
 oci-spec = { git = "https://github.com/containers/oci-spec-rs" }
-ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", rev = "251ed40822f4d243a59bdd395cccdcbae2bca2be" }
+ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", rev = "e28e1d922aad72f3faeff480fc26af9c7643124c" }
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
 sha2 = ">=0.10"


### PR DESCRIPTION
The CI workflow is failing at the moment as the currently pinned
version of ocicrypt-rs has conflicting versions of tonic and prost in
it's dependencies. Let try the latest version to see if that helps

Fixes: #41
Signed-off-by: stevenhorsman <steven@uk.ibm.com>