### PR TITLE
Enable CI check for signature module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run cargo test with root privilege
         run: |
-          sudo -E PATH=$PATH -s cargo test
+          sudo -E PATH=$PATH -s cargo test --all
 
       - name: Run cargo fmt check
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,8 @@ log = "0.4.14"
 filetime = "0.2"
 tempfile = "3.2"
 
+[workspace]
+members = ["signature"]
+exclude = ["scripts/attestation_agent/app"]
+
 [build-dependencies]

--- a/signature/src/image/digest.rs
+++ b/signature/src/image/digest.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use std::string::ToString;
 
 // Supported digest algorithm types
-#[derive(EnumString, Display, Debug, PartialEq, EnumProperty)]
+#[derive(EnumString, Display, Debug, PartialEq, Eq, EnumProperty)]
 pub enum Algorithm {
     #[strum(serialize = "sha256", props(Length = "64"))]
     Sha256,
@@ -55,7 +55,7 @@ impl Error for ParseError {}
 //
 // This allows to abstract the digest behind this type and work only in those
 // terms.
-#[derive(Default, PartialEq, Debug, Clone)]
+#[derive(Default, PartialEq, Eq, Debug, Clone)]
 pub struct Digest {
     algorithm: String,
     value: String,

--- a/signature/src/image/mod.rs
+++ b/signature/src/image/mod.rs
@@ -10,7 +10,7 @@ pub mod digest;
 
 use digest::Digest;
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+#[derive(EnumString, Display, Debug, PartialEq, Eq)]
 pub enum TransportName {
     #[strum(to_string = "docker")]
     Docker,

--- a/signature/src/mechanism/simple/mod.rs
+++ b/signature/src/mechanism/simple/mod.rs
@@ -40,7 +40,7 @@ pub const SIG_STORE_CONFIG_KBS: &str = "Sigstore Config";
 /// The name of gpg key ring to request sigstore config from kbs
 pub const GPG_KEY_RING_KBS: &str = "GPG Keyring";
 
-#[derive(Deserialize, Debug, PartialEq, Serialize, Default)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Serialize, Default)]
 pub struct SimpleParameters {
     // KeyType specifies what kind of the public key to verify the signatures.
     #[serde(rename = "keyType")]
@@ -160,7 +160,7 @@ impl SignScheme for SimpleParameters {
     }
 }
 
-#[derive(Deserialize, EnumString, Display, Debug, PartialEq, Clone)]
+#[derive(Deserialize, EnumString, Display, Debug, PartialEq, Eq, Clone)]
 pub enum KeyType {
     #[strum(to_string = "GPGKeys")]
     Gpg,

--- a/signature/src/mechanism/simple/verify.rs
+++ b/signature/src/mechanism/simple/verify.rs
@@ -123,13 +123,13 @@ impl SigKeyIDs {
         {
             Ok(())
         } else {
-            return Err(
+            Err(
                 anyhow!(
                     "Key ID not matched. trusted key id is: {:X?}, but key id in signature info is: {:X?}", 
                     &self.trusted_key_id,
                     &self.sig_info_key_id
                 )
-            );
+            )
         }
     }
 }
@@ -206,7 +206,7 @@ pub fn verify_sig_and_extract_payload(pubkey_ring: Vec<u8>, sig: Vec<u8>) -> Res
         let sig_payload = serde_json::from_str::<SigPayload>(&body_message)?;
         Ok(sig_payload)
     } else {
-        return Err(anyhow!("Signature format error: no literal field in it!"));
+        Err(anyhow!("Signature format error: no literal field in it!"))
     }
 }
 

--- a/signature/src/policy/mod.rs
+++ b/signature/src/policy/mod.rs
@@ -17,7 +17,7 @@ use self::policy_requirement::PolicyReqType;
 pub mod policy_requirement;
 pub mod ref_match;
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+#[derive(EnumString, Display, Debug, PartialEq, Eq)]
 pub enum ErrorInfo {
     #[strum(to_string = "Match reference failed.")]
     MatchReference,

--- a/signature/src/policy/policy_requirement.rs
+++ b/signature/src/policy/policy_requirement.rs
@@ -16,7 +16,7 @@ use crate::{
 /// * `Reject`: s.t. `reject`, reject the image directly.
 /// * `SignedBy`: s.t. `signBy`, means that the image is signed by `Simple Signing`,
 /// and the related parameters are inside the enum.
-#[derive(Deserialize, Debug, PartialEq, Serialize)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "type")]
 pub enum PolicyReqType {
     /// Accept all images

--- a/signature/src/policy/ref_match.rs
+++ b/signature/src/policy/ref_match.rs
@@ -13,7 +13,7 @@ use crate::policy::ErrorInfo;
 
 /// The `signedIdentity` field in simple signing. It is a JSON object, specifying what image
 /// identity the signature claims about the image.
-#[derive(Deserialize, Debug, PartialEq, Serialize)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "type")]
 pub enum PolicyReqMatchType {
     /// `matchExact` match type : the two references must match exactly.


### PR DESCRIPTION
The unit tests for signature submodule is not enabled by the CI.

Fixes: #48
