### PR TITLE
fix: uniform port setting for AA

### DIFF
--- a/signature/src/agent.rs
+++ b/signature/src/agent.rs
@@ -34,7 +34,7 @@ pub const POLICY_FILE_PATH: &str = "/run/image-security/security_policy.json";
 
 /// Attestation Agent's GetResource gRPC address.
 /// It's given <https://github.com/confidential-containers/attestation-agent#run>
-pub const AA_GETRESOURCE_ADDR: &str = "http://127.0.0.1:48888";
+pub const AA_GETRESOURCE_ADDR: &str = "http://127.0.0.1:50001";
 
 /// Signature submodule agent for image signature veriication.
 pub struct Agent {

--- a/test_data/ocicrypt_keyprovider.conf
+++ b/test_data/ocicrypt_keyprovider.conf
@@ -1,7 +1,7 @@
 {
     "key-providers": {
         "attestation-agent": {
-            "grpc": "127.0.0.1:47777"
+            "grpc": "127.0.0.1:50000"
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -22,9 +22,9 @@ pub fn start_attestation_agent() -> Result<Child> {
 
     Ok(Command::new(aa_path)
         .args(&["--keyprovider_sock"])
-        .args(&["127.0.0.1:47777"])
+        .args(&["127.0.0.1:50000"])
         .args(&["--getresource_sock"])
-        .args(&["127.0.0.1:48888"])
+        .args(&["127.0.0.1:50001"])
         .spawn()?)
 }
 


### PR DESCRIPTION
due to
https://github.com/confidential-containers/attestation-agent/issues/76,
all CCv0 components should use an uniform port
setting, which is beneficial to dev/test/deploy.
The port setting is the same as CCv0 in
https://github.com/confidential-containers/kata-containers-CCv0/blob/CCv0/src/agent/src/image_rpc.rs#L31

Signed-off-by: Xynnn007 <mading.ma@alibaba-inc.com>