### PR TITLE
fix: correct digest for uncompressed layer

### DIFF
--- a/src/pull.rs
+++ b/src/pull.rs
@@ -135,8 +135,23 @@ impl PullClient {
                 };
 
                 if layer_meta.decoder == Compression::Uncompressed {
-                    layer_meta.uncompressed_digest = layer.digest.clone();
-                    layer_meta.compressed_digest = layer.digest.clone();
+                    let digest = if diff_ids[i].starts_with(DIGEST_SHA256) {
+                        format!(
+                            "{}:{:x}",
+                            DIGEST_SHA256,
+                            sha2::Sha256::digest(&plaintext_layer.as_slice())
+                        )
+                    } else if diff_ids[i].starts_with(DIGEST_SHA512) {
+                        format!(
+                            "{}:{:x}",
+                            DIGEST_SHA512,
+                            sha2::Sha512::digest(&plaintext_layer.as_slice())
+                        )
+                    } else {
+                        return Err(anyhow!("unsupported digest format: {}", diff_ids[i]));
+                    };
+                    layer_meta.uncompressed_digest = digest.clone();
+                    layer_meta.compressed_digest = digest;
                 } else {
                     layer_meta.compressed_digest = layer.digest.clone();
                     layer_meta


### PR DESCRIPTION
## Description
The `pub struct PullClient` has a method `pub async fn pull_layers` to download, decrypt and decompress layers. In the [line 137](https://github.com/confidential-containers/image-rs/blob/d772f4d23d814c1f48066ea917ce1e426996be64/src/pull.rs#L137), the client will assign the value `layer.digest.clone()`  which is the layer digest from the image manifest, to the `layer_meta.uncompressed_digest` and `layer_meta.compressed_digest` if the layer is uncompressed. 

However, if a layer is encrypted and uncompressed, the digest from the image manifest is evaluated on the **encrypted layer**, obviously which is not equal to the digest evaluated on the **plaintext layer**.

## Solution
The client need to re-evaluate the digest on the plaintext layer for the uncompressed layer, just like for the compressed layer.

Signed-off-by: haokun.xing <haokun.xin@intel.com>