### PR TITLE
signature: Add Send/Sync support for SignScheme trait

### DIFF
--- a/signature/src/mechanism/mod.rs
+++ b/signature/src/mechanism/mod.rs
@@ -25,7 +25,7 @@ pub mod simple;
 
 /// The interface of a signing scheme
 #[async_trait]
-pub trait SignScheme {
+pub trait SignScheme: Send + Sync {
     /// Do initialization jobs for this scheme. This may include the following
     /// * preparing runtime directories for storing signatures, configurations, etc.
     /// * gathering necessary files.


### PR DESCRIPTION
Fix the building error of kata-agent:
error: future cannot be sent between threads safely
   --> src/image_rpc.rs:265:50
    |
265 |       ) -> ttrpc::Result<image::PullImageResponse> {
    |  __________________________________________________^
266 | |         match self.pull_image(&req).await {
267 | |             Ok(r) => {
268 | |                 let mut resp = image::PullImageResponse::new();
...   |
275 | |         }
276 | |     }
    | |_____^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `dyn signature::mechanism::SignScheme`
note: future is not `Send` as this value is used across an await

Signed-off-by: Wang, Arron <arron.wang@intel.com>