### PR TITLE
pull: Refactor pull_layers()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,10 @@ strum = "0.24"
 strum_macros = "0.24"
 serial_test = "0.9.0"
 rstest = "0.15.0"
+test-utils = { path = "libs/test-utils" }
 
 [workspace]
-members = ["signature"]
+members = ["signature", "libs/test-utils"]
 exclude = ["scripts/attestation_agent/app"]
 
 [features]

--- a/libs/test-utils/Cargo.toml
+++ b/libs/test-utils/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test-utils"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/libs/test-utils/src/lib.rs
+++ b/libs/test-utils/src/lib.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Parameters:
+//
+// 1: expected Result
+// 2: actual Result
+// 3: string used to identify the test on error
+#[macro_export]
+macro_rules! assert_result {
+    ($expected_result:expr, $actual_result:expr, $msg:expr) => {
+        if $expected_result.is_ok() {
+            let expected_value = $expected_result.as_ref().unwrap();
+            let actual_value = $actual_result.unwrap();
+            assert!(*expected_value == actual_value, "{}", $msg);
+        } else {
+            assert!($actual_result.is_err(), "{}", $msg);
+
+            let expected_error = $expected_result.as_ref().unwrap_err();
+            let expected_error_msg = format!("{:?}", expected_error);
+
+            let actual_error_msg = format!("{:?}", $actual_result.unwrap_err());
+
+            assert!(expected_error_msg == actual_error_msg, "{}", $msg);
+        }
+    };
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -27,7 +27,7 @@ use crate::snapshots::occlum::unionfs::Unionfs;
 use crate::snapshots::{SnapshotType, Snapshotter};
 
 /// The metadata info for container image layer.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 pub struct LayerMeta {
     /// Image layer compression algorithm type.
     pub decoder: Compression,

--- a/src/meta_store.rs
+++ b/src/meta_store.rs
@@ -10,7 +10,7 @@ use crate::image::{ImageMeta, LayerMeta};
 pub const METAFILE: &str = "meta_store.json";
 
 /// `image-rs` container metadata storage database.
-#[derive(Clone, Default, Deserialize)]
+#[derive(Clone, Default, Deserialize, Debug)]
 pub struct MetaStore {
     // image_db holds map of image ID with image data.
     pub image_db: HashMap<String, ImageMeta>,


### PR DESCRIPTION
Split the `pull_layers()` method which now calls `handle_layer()` to
reduce the length and complexity of the original function.

Also implemented `TryFrom` for `Compression` (and added some unit tests)
to further simplify the code.

> **Note:**
>
> This PR also contains a new `assert_result!()` test macro that was
> originally written by me as `assert_log_level!()` for Kata Containers
> on:
>
> - https://github.com/kata-containers/kata-containers/pull/65
>
> ... but which now exists in Kata Containers as `assert_result!()` here:
>
> - https://github.com/kata-containers/kata-containers/blob/2b5dc2ad39b9b077246e5bc17c91cc2578c22497/src/libs/test-utils/src/lib.rs#L68

Fixes: #54.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>