### PR TITLE
fix: CI lint

### DIFF
--- a/src/pull.rs
+++ b/src/pull.rs
@@ -147,13 +147,13 @@ impl PullClient {
                 format!(
                     "{}:{:x}",
                     DIGEST_SHA256,
-                    sha2::Sha256::digest(&plaintext_layer.as_slice())
+                    sha2::Sha256::digest(plaintext_layer.as_slice())
                 )
             } else if diff_id.starts_with(DIGEST_SHA512) {
                 format!(
                     "{}:{:x}",
                     DIGEST_SHA512,
-                    sha2::Sha512::digest(&plaintext_layer.as_slice())
+                    sha2::Sha512::digest(plaintext_layer.as_slice())
                 )
             } else {
                 return Err(anyhow!("{}: {:?}", ERR_BAD_UNCOMPRESSED_DIGEST, diff_id));


### PR DESCRIPTION
Fix the lint error:
```plaintext
error: the borrowed expression implements the required traits
Error:    --> src/pull.rs:150:42
    |
150 |                     sha2::Sha256::digest(&plaintext_layer.as_slice())
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `plaintext_layer.as_slice()`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
Error:    --> src/pull.rs:156:42
    |
156 |                     sha2::Sha512::digest(&plaintext_layer.as_slice())
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `plaintext_layer.as_slice()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```