### PR TITLE
features: support native signature client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features
+          args: --features default
 
       - name: Run cargo test with root privilege
         run: |
-          sudo -E PATH=$PATH -s cargo test --all --all-features
+          sudo -E PATH=$PATH -s cargo test --all --features default
 
       - name: Run cargo fmt check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci_eaa_kbc.yml
+++ b/.github/workflows/ci_eaa_kbc.yml
@@ -1,0 +1,60 @@
+name: image-rs eaa_kbc build
+on:
+  pull_request:
+    paths:
+      - 'signature/**'
+
+jobs:
+  ci:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+    # Run all steps in the compilation testing containers
+    container:
+      image: runetest/compilation-testing:ubuntu18.04
+      env:
+        LD_LIBRARY_PATH: /usr/local/lib/rats-tls
+
+    steps:
+      - name: Update cargo home
+        run: |
+          apt-get update && apt-get install -y cargo
+          cp -r /root/.cargo /github/home/.cargo
+
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - name: Install nettle-sys building dependence
+        run: |
+          apt-get install -y clang llvm pkg-config nettle-dev protobuf-compiler libprotobuf-dev
+
+      - name: Build and install rats-tls
+        run: | 
+          apt-get install -y libcurl4-openssl-dev
+          git clone https://github.com/inclavare-containers/rats-tls
+          cd rats-tls
+          cmake -DBUILD_SAMPLES=on -H. -Bbuild
+          make -C build install
+
+      - name: Code checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features occlum_feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ libc = "0.2"
 nix = "0.23.0"
 oci-distribution = "0.9.3"
 oci-spec = { git = "https://github.com/containers/oci-spec-rs" }
-ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", tag = "v0.2.0" }
+ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", tag = "v0.2.0", optional = true }
+
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
 sha2 = ">=0.10"
@@ -26,7 +27,7 @@ zstd = "0.9"
 fs_extra = "1.2.0"
 walkdir = "2"
 dircpy = "0.3.12"
-signature = { path = "./signature" }
+signature = { path = "./signature", optional = true }
 prost = "0.8"
 strum = { version = "0.23.0", features = ["derive"] }
 log = "0.4.14"
@@ -45,8 +46,6 @@ members = ["signature", "libs/test-utils"]
 exclude = ["scripts/attestation_agent/app"]
 
 [features]
-default = ["overlay_feature"]
+default = ["overlay_feature", "ocicrypt-rs", "signature"]
 overlay_feature = []
-occlum_feature = []
-
-[build-dependencies]
+occlum_feature = ["ocicrypt-rs/eaa_kbc", "signature/eaa_kbc"]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -20,6 +20,8 @@ tonic = "0.5"
 prost = "0.8"
 strum_macros = "0.24.2"
 sigstore_rs = { git = "https://github.com/sigstore/sigstore-rs", rev = "6dd3281c25270f0d82550368abfb399ed3da7b41", package = "sigstore" }
+ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", optional = true }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent", rev = "3b4716dd3d8bbf0d5f8cec7bc0d528421f00fd06", optional = true }
 
 [build-dependencies]
 tonic-build = "0.5"
@@ -28,3 +30,7 @@ shadow-rs = "0.17.1"
 [dev-dependencies]
 rstest = "0.15.0"
 serial_test = "0.9.0"
+
+[features]
+default = ["attestation_agent/default", "ocicrypt-rs/default"]
+eaa_kbc = ["attestation_agent/eaa_kbc", "ocicrypt-rs/eaa_kbc"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,6 @@ impl Default for ImageConfig {
         let work_dir = PathBuf::from(
             std::env::var(CC_IMAGE_WORK_DIR).unwrap_or_else(|_| DEFAULT_WORK_DIR.to_string()),
         );
-
         ImageConfig {
             work_dir,
             default_snapshot: SnapshotType::Overlay,


### PR DESCRIPTION
Enclave-cc plans to replace the gRPC AA (attestation agent) with an native AA in the [issue 21](https://github.com/confidential-containers/enclave-cc/issues/21) . Currently, the signature sub-crate in this repo only supports communicating AA via gRPC socket. This PR adds an native signature client that uses an native AA to communicate with the remote KBS.

The PR uses the environment variable "ENABLE_SECURITY_VALIDATE" to enable image signature verification and loads the config file of the ocicrypt-rs to determine whether the AA is native.

Signed-off-by: haokun.xing <haokun.xin@intel.com>