### PR TITLE
image: Update layer db with all success pulled layers

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -293,6 +293,7 @@ impl ImageClient {
             unique_layers.push(l.clone());
         }
 
+        let unique_layers_len = unique_layers.len();
         let layer_metas = client
             .pull_layers(
                 unique_layers,
@@ -310,6 +311,12 @@ impl ImageClient {
             .collect();
 
         self.meta_store.lock().await.layer_db.extend(layer_db);
+        if unique_layers_len != image_data.layer_metas.len() {
+            return Err(anyhow!(
+                " {} layers failed to pull",
+                unique_layers_len - image_data.layer_metas.len()
+            ));
+        }
 
         let image_id = create_bundle(&image_data, bundle_dir, snapshot)?;
 

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -94,7 +94,11 @@ impl<'a> PullClient<'a> {
             }
         });
 
-        let layer_metas = future::try_join_all(layer_metas).await?;
+        let layer_metas = future::join_all(layer_metas)
+            .await
+            .into_iter()
+            .filter_map(|v| v.ok())
+            .collect();
 
         Ok(layer_metas)
     }


### PR DESCRIPTION
Some layers may failed to pull with network issues, orchectration framwork like k8s will trigger repull, we can skip layers pulled successfully last time.

Signed-off-by: Wang, Arron <arron.wang@intel.com>