### PR TITLE
fix: remove hard reference of SimpleSigning in sigstore-rs

### DIFF
--- a/src/signature/payload/simple_signing.rs
+++ b/src/signature/payload/simple_signing.rs
@@ -5,17 +5,20 @@
 
 //! Payload format of simple signing
 
+use std::collections::HashMap;
+
 use anyhow::{anyhow, Result};
 use oci_distribution::Reference;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::signature::policy::ref_match::PolicyReqMatchType;
 
 // The spec of SigPayload is defined in https://github.com/containers/image/blob/main/docs/containers-signature.5.md.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SigPayload {
-    #[serde(flatten)]
-    inner: sigstore_rs::simple_signing::SimpleSigning,
+    pub critical: Critical,
+    pub optional: Option<Optional>,
 }
 
 impl SigPayload {
@@ -43,50 +46,75 @@ impl SigPayload {
     }
 
     fn manifest_digest(&self) -> String {
-        self.inner.critical.image.docker_manifest_digest.clone()
+        self.critical.image.docker_manifest_digest.clone()
     }
 
     fn docker_reference(&self) -> String {
-        self.inner.critical.identity.docker_reference.clone()
+        self.critical.identity.docker_reference.clone()
     }
-}
-
-// A JSON object which contains data critical to correctly evaluating the validity of a signature.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-struct SigPayloadCritical {
-    r#type: String,
-    pub image: PayloadCriticalImage,
-    pub identity: PayloadCriticalIdentity,
-}
-
-// A JSON object which identifies the container image this signature applies to.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-struct PayloadCriticalImage {
-    // A JSON string, in the github.com/opencontainers/go-digest.Digest string format.
-    #[serde(rename = "docker-manifest-digest")]
-    pub docker_manifest_digest: String,
-}
-
-// A JSON object which identifies the claimed identity of the image
-// (usually the purpose of the image, or the application, along with a version information),
-// as asserted by the author of the signature.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-struct PayloadCriticalIdentity {
-    // A JSON string, in the github.com/docker/distribution/reference string format,
-    // and using the same normalization semantics
-    // (where e.g. busybox:latest is equivalent to docker.io/library/busybox:latest).
-    // If the normalization semantics allows multiple string representations
-    // of the claimed identity with equivalent meaning,
-    // the critical.identity.docker-reference member SHOULD use the fully explicit form
-    // (including the full host name and namespaces).
-    #[serde(rename = "docker-reference")]
-    pub docker_reference: String,
 }
 
 impl From<sigstore_rs::simple_signing::SimpleSigning> for SigPayload {
-    fn from(ori: sigstore_rs::simple_signing::SimpleSigning) -> Self {
-        Self { inner: ori }
+    fn from(s: sigstore_rs::simple_signing::SimpleSigning) -> Self {
+        Self {
+            critical: Critical {
+                type_name: s.critical.type_name,
+                image: Image {
+                    docker_manifest_digest: s.critical.image.docker_manifest_digest,
+                },
+                identity: Identity {
+                    docker_reference: s.critical.identity.docker_reference,
+                },
+            },
+            optional: s.optional.map(|opt| Optional {
+                creator: opt.creator,
+                timestamp: opt.timestamp,
+                extra: opt.extra,
+            }),
+        }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+/// A JSON object which contains data critical to correctly evaluating the validity of a signature.
+pub struct Critical {
+    #[serde(rename = "type")]
+    pub type_name: String,
+    pub image: Image,
+    pub identity: Identity,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+/// A JSON object which identifies the container image this signature applies to.
+pub struct Image {
+    /// A JSON string, in the github.com/opencontainers/go-digest.Digest string format.
+    pub docker_manifest_digest: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+/// A JSON object which identifies the claimed identity of the image
+/// (usually the purpose of the image, or the application, along with a version information),
+/// as asserted by the author of the signature.
+pub struct Identity {
+    /// A JSON string, in the github.com/docker/distribution/reference string format,
+    /// and using the same normalization semantics
+    /// (where e.g. busybox:latest is equivalent to docker.io/library/busybox:latest).
+    /// If the normalization semantics allows multiple string representations
+    /// of the claimed identity with equivalent meaning,
+    /// the critical.identity.docker-reference member SHOULD use the fully explicit form
+    /// (including the full host name and namespaces).
+    pub docker_reference: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Optional {
+    pub creator: Option<String>,
+    pub timestamp: Option<i64>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
 #[cfg(test)]
@@ -94,6 +122,8 @@ mod tests {
     use std::collections::HashMap;
 
     use serde_json::json;
+
+    use crate::signature::payload::simple_signing::{Critical, Identity, Image, Optional};
 
     use super::SigPayload;
 
@@ -116,22 +146,22 @@ mod tests {
         });
 
         let payload = SigPayload {
-            inner: sigstore_rs::simple_signing::SimpleSigning {
-                critical: sigstore_rs::simple_signing::Critical {
-                    type_name: "atomic container signature".into(),
-                    image: sigstore_rs::simple_signing::Image {
-                        docker_manifest_digest: "sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a".into(),
-                    },
-                    identity: sigstore_rs::simple_signing::Identity {
-                        docker_reference: "quay.io/ali_os_security/alpine:latest".into(),
-                    },
+            critical: Critical {
+                type_name: "atomic container signature".into(),
+                image: Image {
+                    docker_manifest_digest:
+                        "sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a"
+                            .into(),
                 },
-                optional: Some(sigstore_rs::simple_signing::Optional {
-                    creator: Some("atomic 2.0.0".into()),
-                    timestamp: Some(1634533638),
-                    extra: HashMap::new(),
-                }),
+                identity: Identity {
+                    docker_reference: "quay.io/ali_os_security/alpine:latest".into(),
+                },
             },
+            optional: Some(Optional {
+                creator: Some("atomic 2.0.0".into()),
+                timestamp: Some(1634533638),
+                extra: HashMap::new(),
+            }),
         };
 
         let payload_serialize = serde_json::to_value(&payload).unwrap();
@@ -160,45 +190,27 @@ mod tests {
         // comparation one by one.
         let deserialized_payload: SigPayload = serde_json::from_str(json).unwrap();
         assert_eq!(
-            deserialized_payload
-                .inner
-                .critical
-                .identity
-                .docker_reference,
+            deserialized_payload.critical.identity.docker_reference,
             "quay.io/ali_os_security/alpine:latest"
         );
         assert_eq!(
-            deserialized_payload
-                .inner
-                .critical
-                .image
-                .docker_manifest_digest,
+            deserialized_payload.critical.image.docker_manifest_digest,
             "sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a"
         );
         assert_eq!(
-            deserialized_payload.inner.critical.type_name,
+            deserialized_payload.critical.type_name,
             "atomic container signature"
         );
         assert_eq!(
-            deserialized_payload
-                .inner
-                .optional
-                .as_ref()
-                .unwrap()
-                .creator,
+            deserialized_payload.optional.as_ref().unwrap().creator,
             Some("atomic 2.0.0".into())
         );
         assert_eq!(
-            deserialized_payload
-                .inner
-                .optional
-                .as_ref()
-                .unwrap()
-                .timestamp,
+            deserialized_payload.optional.as_ref().unwrap().timestamp,
             Some(1634533638)
         );
         assert_eq!(
-            deserialized_payload.inner.optional.as_ref().unwrap().extra,
+            deserialized_payload.optional.as_ref().unwrap().extra,
             HashMap::new()
         );
     }


### PR DESCRIPTION
This commit defined a Simple Signing payload of image-rs' own, which avoids "leaking" sigstore-rs types when using SigPayload structure in image-rs.

Signed-off-by: Xynnn007 <xynnn@linux.alibaba.com>