### PR TITLE
Add feature for image-rs with defaults except cosign

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ exclude = ["scripts/attestation_agent/app"]
 
 [features]
 default = ["overlay_feature", "ocicrypt-rs", "attestation_agent/default", "ocicrypt-rs/default", "cosign"]
+default_s390x = ["overlay_feature", "ocicrypt-rs", "attestation_agent/default", "ocicrypt-rs/default"]
 cosign = ["dep:sigstore_rs"]
 overlay_feature = []
 occlum_feature = ["eaa_kbc"]


### PR DESCRIPTION
Add a feature that can be specificed by crates that include the image-rs crate to build image-rs with all default features except cosign.

Fixes confidential-containers#88

Signed-off-by: Matthew Arnold <mattarno@uk.ibm.com>