### PR TITLE
docs: remove commas in example policy.json

### DIFF
--- a/docs/quickstart/image_signing.md
+++ b/docs/quickstart/image_signing.md
@@ -101,8 +101,8 @@ Firstly edit an `policy.json` like
                     "type": "sigstoreSigned",
                     "keyPath": "/run/image-security/cosign/cosign.pub"
                 }
-            ],
-        },
+            ]
+        }
     }
 }
 ```


### PR DESCRIPTION
minor tweak to image signing quickstart guide. making it easier to copy the example policy file

Fixes: #111

Signed-off-by: Alex Carter <Alex.Carter@ibm.com>