### PR TITLE
feat: add feature to control secure_channel

### DIFF
--- a/.github/workflows/ci_eaa_kbc.yml
+++ b/.github/workflows/ci_eaa_kbc.yml
@@ -18,7 +18,7 @@ jobs:
           - nightly
     # Run all steps in the compilation testing containers
     container:
-      image: runetest/compilation-testing:ubuntu18.04
+      image: runetest/compilation-testing:ubuntu20.04
       env:
         LD_LIBRARY_PATH: /usr/local/lib/rats-tls
 
@@ -57,11 +57,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features enclave-cc
+          args: --no-default-features --features enclave-cc,keywrap-native
 
-      - name: Run cargo test - enclave-cc
+      - name: Run cargo test - enclave-cc,keywrap-native
         run: |
-          cargo test --all --no-default-features --features=enclave-cc
+          cargo test --all --no-default-features --features=enclave-cc,keywrap-native
 
       - name: Run cargo test - snapshot-unionfs
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ exclude = ["scripts/attestation_agent/app"]
 
 [features]
 default = ["snapshot-overlayfs", "signature-cosign", "keywrap-grpc"]
-kata-cc = ["encryption", "keywrap-grpc", "snapshot-overlayfs", "signature-cosign"]
-kata-cc-s390x = ["encryption", "keywrap-grpc", "snapshot-overlayfs", "signature-simple"]
-enclave-cc = ["encryption", "keywrap-native", "eaa-kbc", "snapshot-unionfs", "signature-simple"]
+kata-cc = ["encryption", "keywrap-grpc", "snapshot-overlayfs", "signature-cosign", "getresource"]
+kata-cc-s390x = ["encryption", "keywrap-grpc", "snapshot-overlayfs", "signature-simple", "getresource"]
+enclave-cc = ["encryption", "keywrap-native", "eaa-kbc", "snapshot-unionfs", "signature-simple", "getresource"]
 
 encryption = ["ocicrypt-rs/block-cipher"]
 keywrap-cmd = ["ocicrypt-rs/keywrap-keyprovider-cmd"]
@@ -87,3 +87,5 @@ signature-cosign = ["signature", "sigstore"]
 
 snapshot-overlayfs = ["nix"]
 snapshot-unionfs = ["nix", "dircpy", "fs_extra"]
+
+getresource = []

--- a/src/image.rs
+++ b/src/image.rs
@@ -12,17 +12,15 @@ use std::collections::{BTreeSet, HashMap};
 use std::convert::TryFrom;
 use std::path::Path;
 use std::sync::Arc;
-use tokio::fs;
+
 use tokio::sync::Mutex;
 
-use crate::auth::credential_for_reference;
 use crate::bundle::{create_runtime_config, BUNDLE_ROOTFS};
 use crate::config::ImageConfig;
 use crate::decoder::Compression;
 use crate::meta_store::{MetaStore, METAFILE};
 use crate::pull::PullClient;
 
-use crate::secure_channel::SecureChannel;
 use crate::signature;
 
 #[cfg(feature = "snapshot-unionfs")]
@@ -183,11 +181,12 @@ impl ImageClient {
 
         // If one of self.config.auth and self.config.security_validate is enabled,
         // there will establish a secure channel between image-rs and Attestation-Agent
+        #[cfg(feature = "getresource")]
         let secure_channel = match self.config.auth || self.config.security_validate {
             true => {
                 // Both we need a [`IMAGE_SECURITY_CONFIG_DIR`] dir
                 if !Path::new(IMAGE_SECURITY_CONFIG_DIR).exists() {
-                    fs::create_dir_all(IMAGE_SECURITY_CONFIG_DIR)
+                    tokio::fs::create_dir_all(IMAGE_SECURITY_CONFIG_DIR)
                         .await
                         .map_err(|e| {
                             anyhow!("Create image security runtime config dir failed: {:?}", e)
@@ -200,8 +199,9 @@ impl ImageClient {
                         wrapped_aa_kbc_params.trim_start_matches("provider:attestation-agent:");
 
                     // The secure channel to communicate with KBS.
-                    let secure_channel =
-                        Arc::new(Mutex::new(SecureChannel::new(aa_kbc_params).await?));
+                    let secure_channel = Arc::new(Mutex::new(
+                        crate::secure_channel::SecureChannel::new(aa_kbc_params).await?,
+                    ));
                     Some(secure_channel)
                 } else {
                     bail!("Secure channel creation needs aa_kbc_params.");
@@ -214,13 +214,14 @@ impl ImageClient {
         // auth from `auth.json`.
         // If a proper auth is given, use this auth.
         // If no valid auth is given and config.auth is disabled, use Anonymous auth.
+        #[cfg(feature = "getresource")]
         let auth = match (self.config.auth, auth.is_none()) {
             (true, true) => {
                 let secure_channel = secure_channel
                     .as_ref()
                     .expect("unexpected uninitialized secure channel")
                     .clone();
-                match credential_for_reference(&reference, secure_channel).await {
+                match crate::auth::credential_for_reference(&reference, secure_channel).await {
                     Ok(cred) => cred,
                     Err(e) => {
                         warn!(
@@ -231,6 +232,22 @@ impl ImageClient {
                     }
                 }
             }
+            (false, true) => RegistryAuth::Anonymous,
+            _ => auth.expect("unexpected uninitialized auth"),
+        };
+
+        #[cfg(not(feature = "getresource"))]
+        let auth = match (self.config.auth, auth.is_none()) {
+            (true, true) => match crate::auth::credential_for_reference_local(&reference).await {
+                Ok(cred) => cred,
+                Err(e) => {
+                    warn!(
+                        "get credential failed, use Anonymous auth instead: {}",
+                        e.to_string()
+                    );
+                    RegistryAuth::Anonymous
+                }
+            },
             (false, true) => RegistryAuth::Anonymous,
             _ => auth.expect("unexpected uninitialized auth"),
         };
@@ -258,12 +275,20 @@ impl ImageClient {
             }
         }
 
+        #[cfg(all(feature = "getresource", feature = "signature"))]
         if self.config.security_validate {
             let secure_channel = secure_channel
                 .as_ref()
                 .expect("unexpected uninitialized secure channel")
                 .clone();
             signature::allows_image(image_url, &image_digest, secure_channel, &auth)
+                .await
+                .map_err(|e| anyhow!("Security validate failed: {:?}", e))?;
+        }
+
+        #[cfg(all(not(feature = "getresource"), feature = "signature"))]
+        if self.config.security_validate {
+            signature::allows_image(image_url, &image_digest, &auth)
                 .await
                 .map_err(|e| anyhow!("Security validate failed: {:?}", e))?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@ pub mod decrypt;
 pub mod image;
 pub mod meta_store;
 pub mod pull;
+#[cfg(feature = "getresource")]
 pub mod secure_channel;
+#[cfg(feature = "signature")]
 pub mod signature;
 pub mod snapshots;
 pub mod stream;

--- a/src/signature/mechanism/mod.rs
+++ b/src/signature/mechanism/mod.rs
@@ -20,6 +20,8 @@ use anyhow::*;
 use async_trait::async_trait;
 use oci_distribution::secrets::RegistryAuth;
 
+use crate::config::Paths;
+
 use super::image::Image;
 
 #[cfg(feature = "signature-simple")]
@@ -34,7 +36,7 @@ pub trait SignScheme: Send + Sync {
     /// Do initialization jobs for this scheme. This may include the following
     /// * preparing runtime directories for storing signatures, configurations, etc.
     /// * gathering necessary files.
-    async fn init(&self) -> Result<()>;
+    async fn init(&mut self, config: &Paths) -> Result<()>;
 
     /// Reture a HashMap including a resource's name => file path in fs.
     ///

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -3,81 +3,123 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#[cfg(feature = "signature")]
-use std::convert::TryFrom;
-use std::sync::Arc;
-
-use anyhow::Result;
-use oci_distribution::secrets::RegistryAuth;
-use tokio::sync::Mutex;
-
-use crate::secure_channel::SecureChannel;
-
-#[cfg(feature = "signature")]
 pub mod image;
-#[cfg(feature = "signature")]
 pub mod mechanism;
-#[cfg(feature = "signature")]
 pub mod payload;
-#[cfg(feature = "signature")]
 pub mod policy;
 
 /// Default policy file path.
 pub const POLICY_FILE_PATH: &str = "/run/image-security/security_policy.json";
 
-#[cfg(feature = "signature")]
-/// `allows_image` will check all the `PolicyRequirements` suitable for
-/// the given image. The `PolicyRequirements` is defined in
-/// [`POLICY_FILE_PATH`] and may include signature verification.
-pub async fn allows_image(
-    image_reference: &str,
-    image_digest: &str,
-    secure_channel: Arc<Mutex<SecureChannel>>,
-    auth: &RegistryAuth,
-) -> Result<()> {
-    // if Policy config file does not exist, get if from KBS.
-    if !std::path::Path::new(POLICY_FILE_PATH).exists() {
-        secure_channel
-            .lock()
-            .await
-            .get_resource("Policy", std::collections::HashMap::new(), POLICY_FILE_PATH)
-            .await?;
-    }
+#[cfg(feature = "getresource")]
+pub use getresource::allows_image;
 
-    let reference = oci_distribution::Reference::try_from(image_reference)?;
-    let mut image = self::image::Image::default_with_reference(reference);
-    image.set_manifest_digest(image_digest)?;
+#[cfg(not(feature = "getresource"))]
+pub use no_getresource::allows_image;
 
-    // Read the set of signature schemes that need to be verified
-    // of the image from the policy configuration.
-    let policy = self::policy::Policy::from_file(POLICY_FILE_PATH).await?;
-    let schemes = policy.signature_schemes(&image);
+#[cfg(feature = "getresource")]
+pub mod getresource {
+    use crate::secure_channel::SecureChannel;
+    use crate::signature::policy::Policy;
 
-    // Get the necessary resources from KBS if needed.
-    for scheme in schemes {
-        scheme.init().await?;
-        let resource_manifest = scheme.resource_manifest();
-        for (resource_name, path) in resource_manifest {
+    use super::image::Image;
+    use super::POLICY_FILE_PATH;
+
+    use std::convert::TryFrom;
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use oci_distribution::secrets::RegistryAuth;
+    use tokio::sync::Mutex;
+
+    /// `allows_image` will check all the `PolicyRequirements` suitable for
+    /// the given image. The `PolicyRequirements` is defined in
+    /// [`POLICY_FILE_PATH`] and may include signature verification.
+    #[cfg(all(feature = "getresource", feature = "signature"))]
+    pub async fn allows_image(
+        image_reference: &str,
+        image_digest: &str,
+        secure_channel: Arc<Mutex<SecureChannel>>,
+        auth: &RegistryAuth,
+    ) -> Result<()> {
+        // if Policy config file does not exist, get if from KBS.
+
+        if !std::path::Path::new(POLICY_FILE_PATH).exists() {
             secure_channel
                 .lock()
                 .await
-                .get_resource(resource_name, std::collections::HashMap::new(), path)
+                .get_resource("Policy", std::collections::HashMap::new(), POLICY_FILE_PATH)
                 .await?;
         }
-    }
 
-    policy
-        .is_image_allowed(image, auth)
-        .await
-        .map_err(|e| anyhow::anyhow!("Validate image failed: {:?}", e))
+        let reference = oci_distribution::Reference::try_from(image_reference)?;
+        let mut image = Image::default_with_reference(reference);
+        image.set_manifest_digest(image_digest)?;
+
+        // Read the set of signature schemes that need to be verified
+        // of the image from the policy configuration.
+        let policy = Policy::from_file(POLICY_FILE_PATH).await?;
+        let schemes = policy.signature_schemes(&image);
+
+        // Get the necessary resources from KBS if needed.
+        for scheme in schemes {
+            scheme.init().await?;
+            let resource_manifest = scheme.resource_manifest();
+            for (resource_name, path) in resource_manifest {
+                secure_channel
+                    .lock()
+                    .await
+                    .get_resource(resource_name, std::collections::HashMap::new(), path)
+                    .await?;
+            }
+        }
+
+        policy
+            .is_image_allowed(image, auth)
+            .await
+            .map_err(|e| anyhow::anyhow!("Validate image failed: {:?}", e))
+    }
 }
 
-#[cfg(not(feature = "signature"))]
-pub async fn allows_image(
-    _image_reference: &str,
-    _image_digest: &str,
-    _secure_channel: Arc<Mutex<SecureChannel>>,
-    _auth: &RegistryAuth,
-) -> Result<()> {
-    Ok(())
+#[cfg(not(feature = "getresource"))]
+pub mod no_getresource {
+    use std::convert::TryFrom;
+
+    use anyhow::Result;
+    use log::warn;
+    use oci_distribution::secrets::RegistryAuth;
+
+    use crate::signature::{image::Image, policy::Policy, POLICY_FILE_PATH};
+
+    pub async fn allows_image(
+        image_reference: &str,
+        image_digest: &str,
+        auth: &RegistryAuth,
+    ) -> Result<()> {
+        // if Policy config file does not exist, get if from KBS.
+
+        if !std::path::Path::new(POLICY_FILE_PATH).exists() {
+            warn!("Non {POLICY_FILE_PATH} found, pass validation.");
+            return Ok(());
+        }
+
+        let reference = oci_distribution::Reference::try_from(image_reference)?;
+        let mut image = Image::default_with_reference(reference);
+        image.set_manifest_digest(image_digest)?;
+
+        // Read the set of signature schemes that need to be verified
+        // of the image from the policy configuration.
+        let policy = Policy::from_file(POLICY_FILE_PATH).await?;
+        let schemes = policy.signature_schemes(&image);
+
+        // Get the necessary resources from KBS if needed.
+        for scheme in schemes {
+            scheme.init().await?;
+        }
+
+        policy
+            .is_image_allowed(image, auth)
+            .await
+            .map_err(|e| anyhow::anyhow!("Validate image failed: {:?}", e))
+    }
 }

--- a/src/signature/policy/policy_requirement.rs
+++ b/src/signature/policy/policy_requirement.rs
@@ -63,12 +63,12 @@ impl PolicyReqType {
 
     /// Return the `SignScheme` trait object if it is some signing scheme,
     /// or None if not.
-    pub fn try_into_sign_scheme(&self) -> Option<&dyn SignScheme> {
+    pub fn try_into_sign_scheme(&mut self) -> Option<&mut dyn SignScheme> {
         match self {
             #[cfg(feature = "signature-simple")]
-            PolicyReqType::SimpleSigning(scheme) => Some(scheme as &dyn SignScheme),
+            PolicyReqType::SimpleSigning(scheme) => Some(scheme as &mut dyn SignScheme),
             #[cfg(feature = "signature-cosign")]
-            PolicyReqType::Cosign(scheme) => Some(scheme as &dyn SignScheme),
+            PolicyReqType::Cosign(scheme) => Some(scheme as &mut dyn SignScheme),
             _ => None,
         }
     }
@@ -149,18 +149,27 @@ mod tests {
                 key_path: Some("/keys/public-gpg-keyring".into()),
                 key_data: None,
                 signed_identity: None,
+                sig_store_config_dir: "".into(),
+                default_sig_store_config_file: "".into(),
+                gpg_key_ring: "".into(),
             }),
             PolicyReqType::SimpleSigning(SimpleParameters {
                 key_type: "GPGKeys".into(),
                 key_path: None,
                 key_data: Some("bm9uc2Vuc2U=".into()),
                 signed_identity: None,
+                sig_store_config_dir: "".into(),
+                default_sig_store_config_file: "".into(),
+                gpg_key_ring: "".into(),
             }),
             PolicyReqType::SimpleSigning(SimpleParameters {
                 key_type: "GPGKeys".into(),
                 key_path: Some("/keys/public-gpg-keyring".into()),
                 key_data: None,
                 signed_identity: Some(PolicyReqMatchType::MatchExact),
+                sig_store_config_dir: "".into(),
+                default_sig_store_config_file: "".into(),
+                gpg_key_ring: "".into(),
             }),
             PolicyReqType::SimpleSigning(SimpleParameters {
                 key_type: "GPGKeys".into(),
@@ -169,6 +178,9 @@ mod tests {
                 signed_identity: Some(PolicyReqMatchType::ExactReference {
                     docker_reference: "docker.io/example/busybox:latest".into(),
                 }),
+                sig_store_config_dir: "".into(),
+                default_sig_store_config_file: "".into(),
+                gpg_key_ring: "".into(),
             }),
             PolicyReqType::SimpleSigning(SimpleParameters {
                 key_type: "GPGKeys".into(),
@@ -178,6 +190,9 @@ mod tests {
                     prefix: "example".into(),
                     signed_prefix: "example".into(),
                 }),
+                sig_store_config_dir: "".into(),
+                default_sig_store_config_file: "".into(),
+                gpg_key_ring: "".into(),
             }),
         ];
 

--- a/tests/credential.rs
+++ b/tests/credential.rs
@@ -9,6 +9,7 @@ use serial_test::serial;
 
 mod common;
 
+#[cfg(feature = "getresource")]
 #[rstest]
 #[case("liudalibj/private-busy-box")]
 #[case("quay.io/liudalibj/private-busy-box")]

--- a/tests/image_decryption.rs
+++ b/tests/image_decryption.rs
@@ -18,6 +18,7 @@ const UNENCRYPTED_IMAGE_REFERENCE_OFFLINE_FS_KBS: &str = "docker.io/arronwang/bu
 /// Ocicrypt-rs config
 const OCICRYPT_CONFIG: &str = "test_data/ocicrypt_keyprovider.conf";
 
+#[cfg(feature = "getresource")]
 #[tokio::test]
 #[serial]
 async fn test_decrypt_layers() {

--- a/tests/signature_verification.rs
+++ b/tests/signature_verification.rs
@@ -79,6 +79,7 @@ const TESTS: [TestItem; 6] = [
 /// image-rs built without support for cosign image signing cannot use a policy that includes a type that
 /// uses cosign (type: sigstoreSigned), even if the image being pulled is not signed using cosign.
 /// https://github.com/confidential-containers/attestation-agent/blob/main/src/kbc_modules/sample_kbc/policy.json
+#[cfg(feature = "getresource")]
 #[tokio::test]
 #[serial]
 async fn signature_verification() {


### PR DESCRIPTION
For non-confidential container scenarios, `secure_channel` is not supported. This commit brings a feature `getresource` to control whether to enable `secure_channel`.

Also, add flexibly configurable for paths to support both confidential scenarios and non-confidential scenarios.
Close https://github.com/confidential-containers/image-rs/issues/110

Signed-off-by: Xynnn007 <xynnn@linux.alibaba.com>