### PR TITLE
ci: fix CI error for rats-tls build

### DIFF
--- a/.github/workflows/ci_eaa_kbc.yml
+++ b/.github/workflows/ci_eaa_kbc.yml
@@ -45,6 +45,7 @@ jobs:
           apt-get install -y libcurl4-openssl-dev
           git clone https://github.com/inclavare-containers/rats-tls
           cd rats-tls
+          git reset --hard 8fbfdb6
           cmake -DBUILD_SAMPLES=on -H. -Bbuild
           make -C build install
 


### PR DESCRIPTION
/__w/image-rs/image-rs/rats-tls/src/verifiers/sgx-ecdsa/verify_evidence.c: In function 'ecdsa_verify_evidence': /__w/image-rs/image-rs/rats-tls/src/verifiers/sgx-ecdsa/verify_evidence.c:227:5: error: 'sgx_ql_qve_collateral_t {aka struct _sgx_ql_qve_collateral_t}' has no member named 'tee_type'
    .tee_type = 0x00000000, /* SGX */
     ^~~~~~~~

Signed-off-by: Xynnn007 <xynnn@linux.alibaba.com>