### PR TITLE
fix: use ttrpc instead of grpc as default protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run cargo test - kata-cc,keywrap-grpc
         run: |
-          sudo -E PATH=$PATH -s cargo test --all --no-default-features --features=kata-cc,keywrap-grpc
+          sudo -E PATH=$PATH -s cargo test --all --no-default-features --features=encryption,snapshot-overlayfs,signature-cosign,getresource,keywrap-grpc
 
       - name: Run cargo test - encryption,keywrap-grpc
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,8 +70,8 @@ exclude = ["scripts/attestation_agent/app"]
 
 [features]
 default = ["snapshot-overlayfs", "signature-cosign", "keywrap-grpc"]
-kata-cc = ["encryption", "keywrap-grpc", "snapshot-overlayfs", "signature-cosign", "getresource"]
-kata-cc-s390x = ["encryption", "keywrap-grpc", "snapshot-overlayfs", "signature-simple", "getresource"]
+kata-cc = ["encryption", "keywrap-ttrpc", "snapshot-overlayfs", "signature-cosign", "getresource"]
+kata-cc-s390x = ["encryption", "keywrap-ttrpc", "snapshot-overlayfs", "signature-simple", "getresource"]
 enclave-cc = ["encryption", "keywrap-native", "eaa-kbc", "snapshot-unionfs", "signature-simple", "getresource"]
 
 encryption = ["ocicrypt-rs/block-cipher"]


### PR DESCRIPTION
Close https://github.com/confidential-containers/image-rs/issues/121