### PR TITLE
Fix features of kata-cc and enclave-cc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ exclude = ["scripts/attestation_agent/app"]
 default = ["snapshot-overlayfs", "signature-cosign", "keywrap-grpc"]
 kata-cc = ["encryption", "keywrap-ttrpc", "snapshot-overlayfs", "signature-cosign", "getresource"]
 kata-cc-s390x = ["encryption", "keywrap-ttrpc", "snapshot-overlayfs", "signature-simple", "getresource"]
-enclave-cc = ["encryption", "keywrap-native", "eaa-kbc", "snapshot-unionfs", "signature-simple", "getresource"]
+enclave-cc = ["encryption", "keywrap-native", "eaa-kbc", "snapshot-unionfs", "signature-simple", "getresource", "signature-cosign"]
 
 encryption = ["ocicrypt-rs/block-cipher"]
 keywrap-cmd = ["ocicrypt-rs/keywrap-keyprovider-cmd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ exclude = ["scripts/attestation_agent/app"]
 
 [features]
 default = ["snapshot-overlayfs", "signature-cosign", "keywrap-grpc"]
-kata-cc = ["encryption", "keywrap-ttrpc", "snapshot-overlayfs", "signature-cosign", "getresource"]
+kata-cc = ["encryption", "keywrap-ttrpc", "snapshot-overlayfs", "signature-cosign", "signature-simple", "getresource"]
 kata-cc-s390x = ["encryption", "keywrap-ttrpc", "snapshot-overlayfs", "signature-simple", "getresource"]
 enclave-cc = ["encryption", "keywrap-native", "eaa-kbc", "snapshot-unionfs", "signature-simple", "getresource", "signature-cosign"]
 


### PR DESCRIPTION
enclave-cc should enable `signature-cosign` by default : https://github.com/confidential-containers/enclave-cc/blob/main/src/enclave-agent/Cargo.toml#L16

Kata-cc should enable `signature-simple` by default: https://github.com/kata-containers/kata-containers/blob/CCv0/src/agent/Cargo.toml#L77