### PR TITLE
deps: Update ocicrypt-rs / attestation-agent to v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 anyhow = "1"
 async-compression = { version = "0.3.15", features = ["futures-io", "tokio", "gzip", "zstd"] }
 async-trait = "0.1.56"
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", rev = "c939d21", optional = true }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", tag = "v0.5.0", optional = true }
 base64 = "0.13.0"
 cfg-if = { version = "1.0.0", optional = true }
 dircpy = { version = "0.3.12", optional = true }
@@ -27,7 +27,7 @@ log = "0.4.14"
 nix = { version = "0.26", optional = true }
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }
 oci-spec = "0.5.8"
-ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", rev = "55ab22d", default-features = false, features = ["keywrap-jwe", "async-io"], optional = true }
+ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs", tag = "v0.5.0", default-features = false, features = ["keywrap-jwe", "async-io"], optional = true }
 prost = { version = "0.11", optional = true }
 sequoia-openpgp = { version = "1.7.0", default-features = false, features = ["compression", "crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto"], optional = true }
 protobuf = { version = "3.2.0", optional = true }


### PR DESCRIPTION
Let's use the latest released tag for both ocicrypt-rs and attestation-agent.