### PR TITLE
config: Add max_concurrent_download for pull operation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,9 @@ pub const GPG_KEY_RING: &str = "/run/image-security/simple_signing/pubkey.gpg";
 /// [`AUTH_FILE_PATH`] shows the path to the `auth.json` file.
 pub const AUTH_FILE_PATH: &str = "kbs:///default/credential/test";
 
+/// Default max concurrent download.
+pub const DEFAULT_MAX_CONCURRENT_DOWNLOAD: usize = 3;
+
 /// `image-rs` configuration information.
 #[derive(Clone, Debug, Deserialize)]
 pub struct ImageConfig {
@@ -52,6 +55,11 @@ pub struct ImageConfig {
         deserialize_with = "deserialize_null_default"
     )]
     pub file_paths: Paths,
+
+    /// Maximum number of concurrent downloads to perform during image pull.
+    ///
+    /// This defaults to [`DEFAULT_MAX_CONCURRENT_DOWNLOAD`].
+    pub max_concurrent_download: usize,
 }
 
 /// This function used to parse from string. When it is an
@@ -82,6 +90,7 @@ impl Default for ImageConfig {
             security_validate: false,
             auth: false,
             file_paths: Paths::default(),
+            max_concurrent_download: DEFAULT_MAX_CONCURRENT_DOWNLOAD,
         }
     }
 }
@@ -140,6 +149,10 @@ mod tests {
 
         assert_eq!(config.work_dir, work_dir);
         assert_eq!(config.default_snapshot, SnapshotType::Overlay);
+        assert_eq!(
+            config.max_concurrent_download,
+            DEFAULT_MAX_CONCURRENT_DOWNLOAD
+        );
 
         let env_work_dir = "/tmp";
         std::env::set_var(CC_IMAGE_WORK_DIR, env_work_dir);
@@ -154,7 +167,8 @@ mod tests {
             "work_dir": "/var/lib/image-rs/",
             "default_snapshot": "overlay",
             "security_validate": false,
-            "auth": false
+            "auth": false,
+	    "max_concurrent_download": 1
         }"#;
 
         let tempdir = tempfile::tempdir().unwrap();
@@ -170,6 +184,7 @@ mod tests {
 
         assert_eq!(config.work_dir, work_dir);
         assert_eq!(config.default_snapshot, SnapshotType::Overlay);
+        assert_eq!(config.max_concurrent_download, 1);
 
         let invalid_config_file = tempdir.path().join("does-not-exist");
         assert!(!invalid_config_file.exists());

--- a/src/image.rs
+++ b/src/image.rs
@@ -19,7 +19,7 @@ use crate::bundle::{create_runtime_config, BUNDLE_ROOTFS};
 use crate::config::ImageConfig;
 use crate::decoder::Compression;
 use crate::meta_store::{MetaStore, METAFILE};
-use crate::pull::{PullClient, DEFAULT_MAX_CONCURRENT_DOWNLOAD};
+use crate::pull::PullClient;
 
 #[cfg(feature = "snapshot-unionfs")]
 use crate::snapshots::occlum::unionfs::Unionfs;
@@ -230,14 +230,11 @@ impl ImageClient {
             _ => auth.expect("unexpected uninitialized auth"),
         };
 
-        let max_concurrent_download = std::thread::available_parallelism()
-            .map_or(DEFAULT_MAX_CONCURRENT_DOWNLOAD, |v| v.get());
-
         let mut client = PullClient::new(
             reference,
             &self.config.work_dir.join("layers"),
             &auth,
-            max_concurrent_download,
+            self.config.max_concurrent_download,
         )?;
         let (image_manifest, image_digest, image_config) = client.pull_manifest().await?;
 

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -28,8 +28,6 @@ const ERR_NO_DECRYPT_CFG: &str = "decrypt_config is None";
 const ERR_BAD_UNCOMPRESSED_DIGEST: &str = "unsupported uncompressed digest format";
 const ERR_BAD_COMPRESSED_DIGEST: &str = "unsupported compressed digest format";
 
-pub const DEFAULT_MAX_CONCURRENT_DOWNLOAD: usize = 6;
-
 /// The PullClient connects to remote OCI registry, pulls the container image,
 /// and save the image layers under data_dir and return the layer meta info.
 pub struct PullClient<'a> {
@@ -346,6 +344,7 @@ impl<'a> PullClient<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::DEFAULT_MAX_CONCURRENT_DOWNLOAD;
     use crate::decoder::ERR_BAD_MEDIA_TYPE;
     use flate2::write::GzEncoder;
     use oci_distribution::manifest::IMAGE_CONFIG_MEDIA_TYPE;


### PR DESCRIPTION
`std::thread::available_parallelism()` will get all available cpu num in host side for enclave-cc, export the config for enclave/kata agent to decide.

Thanks @mythi for point this out.

DEFAULT_MAX_CONCURRENT_DOWNLOAD is set to 3 which is the same default config for dockerd.