### PR TITLE
dep: Update ocicrypt-rs & attestation-agent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 anyhow = "1"
 async-compression = { version = "0.3.15", features = ["futures-io", "tokio", "gzip", "zstd"] }
 async-trait = "0.1.56"
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", rev = "aa1d3c5", optional = true }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent.git", tag = "v0.6.0", optional = true }
 base64 = "0.13.0"
 cfg-if = { version = "1.0.0", optional = true }
 dircpy = { version = "0.3.12", optional = true }
@@ -28,7 +28,7 @@ log = "0.4.14"
 nix = { version = "0.26", optional = true }
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c", default-features = false, optional = true }
 oci-spec = "0.5.8"
-ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs.git", rev = "defbacc", default-features = false, features = ["async-io"], optional = true }
+ocicrypt-rs = { git = "https://github.com/confidential-containers/ocicrypt-rs.git", tag = "v0.6.0", default-features = false, features = ["async-io"], optional = true }
 prost = { version = "0.11", optional = true }
 protobuf = { version = "3.2.0", optional = true }
 sequoia-openpgp = { version = "1.7.0", default-features = false, features = ["compression", "crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto"], optional = true }


### PR DESCRIPTION
- Update ocicrypt-rs & attestation-agent to use the v0.6.0 release tag