### PR TITLE
Add some robustness fixes to integration tests

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -111,6 +111,11 @@ pub async fn start_attestation_agent() -> Result<Child> {
     Ok(aa)
 }
 
+pub fn umount_bundle(bundle_dir: &tempfile::TempDir) {
+    let rootfs_path = bundle_dir.path().join("rootfs");
+    nix::mount::umount(&rootfs_path).expect("failed to umount rootfs");
+}
+
 pub async fn clean_configs() -> Result<()> {
     if Path::new(IMAGE_SECURITY_CONFIG_DIR).exists() {
         tokio::fs::remove_dir_all(IMAGE_SECURITY_CONFIG_DIR).await?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -82,6 +82,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "keywrap-ttrpc")] {
             let mut aa = tokio::process::Command::new(aa_path)
+                .kill_on_drop(true)
                 .args(&[
                     "--keyprovider_sock",
                     "unix:///run/confidential-containers/attestation-agent/keyprovider.sock",
@@ -91,6 +92,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
                 .spawn()?;
         } else {
             let mut aa = tokio::process::Command::new(aa_path)
+                .kill_on_drop(true)
                 .args(&[
                     "--keyprovider_sock",
                     "127.0.0.1:50000",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -81,7 +81,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "keywrap-ttrpc")] {
-            let aa = tokio::process::Command::new(aa_path)
+            let mut aa = tokio::process::Command::new(aa_path)
                 .args(&[
                     "--keyprovider_sock",
                     "unix:///run/confidential-containers/attestation-agent/keyprovider.sock",
@@ -90,7 +90,7 @@ pub async fn start_attestation_agent() -> Result<Child> {
                     ])
                 .spawn()?;
         } else {
-            let aa = tokio::process::Command::new(aa_path)
+            let mut aa = tokio::process::Command::new(aa_path)
                 .args(&[
                     "--keyprovider_sock",
                     "127.0.0.1:50000",
@@ -103,6 +103,9 @@ pub async fn start_attestation_agent() -> Result<Child> {
 
     // Leave some time to let fork-ed AA process to be ready
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    if let Some(_) = aa.try_wait()? {
+        panic!("Attestation Agent failed to start");
+    }
     Ok(aa)
 }
 

--- a/tests/credential.rs
+++ b/tests/credential.rs
@@ -19,7 +19,7 @@ async fn test_use_credential(#[case] image_ref: &str, #[case] auth_file_uri: &st
     common::prepare_test().await;
 
     // Init AA
-    let mut aa = common::start_attestation_agent()
+    let _aa = common::start_attestation_agent()
         .await
         .expect("Failed to start attestation agent!");
 
@@ -56,7 +56,5 @@ async fn test_use_credential(#[case] image_ref: &str, #[case] auth_file_uri: &st
         assert!(res.is_err());
     }
 
-    // kill AA when the test is finished
-    aa.kill().await.expect("Failed to stop attestation agent!");
     common::clean().await;
 }

--- a/tests/credential.rs
+++ b/tests/credential.rs
@@ -52,6 +52,7 @@ async fn test_use_credential(#[case] image_ref: &str, #[case] auth_file_uri: &st
         .await;
     if cfg!(all(feature = "snapshot-overlayfs",)) {
         assert!(res.is_ok(), "{:?}", res);
+        common::umount_bundle(&bundle_dir);
     } else {
         assert!(res.is_err());
     }

--- a/tests/image_decryption.rs
+++ b/tests/image_decryption.rs
@@ -52,6 +52,7 @@ async fn test_decrypt_layers(#[case] image: &str) {
             .pull_image(image, bundle_dir.path(), &None, &Some(common::AA_PARAMETER))
             .await
             .expect("failed to download image");
+        common::umount_bundle(&bundle_dir);
     } else {
         image_client
             .pull_image(image, bundle_dir.path(), &None, &Some(common::AA_PARAMETER))

--- a/tests/image_decryption.rs
+++ b/tests/image_decryption.rs
@@ -27,7 +27,7 @@ const OCICRYPT_CONFIG: &str = "test_data/ocicrypt_keyprovider_ttrpc.conf";
 async fn test_decrypt_layers(#[case] image: &str) {
     common::prepare_test().await;
     // Init AA
-    let mut aa = common::start_attestation_agent()
+    let _aa = common::start_attestation_agent()
         .await
         .expect("Failed to start attestation agent!");
 
@@ -48,12 +48,10 @@ async fn test_decrypt_layers(#[case] image: &str) {
         .expect("Delete configs failed.");
     let mut image_client = ImageClient::default();
     if cfg!(feature = "snapshot-overlayfs") {
-        if let Err(e) = image_client
+        image_client
             .pull_image(image, bundle_dir.path(), &None, &Some(common::AA_PARAMETER))
             .await
-        {
-            panic!("test_decrypt_layers() failed to download image, {}", e);
-        }
+            .expect("failed to download image");
     } else {
         image_client
             .pull_image(image, bundle_dir.path(), &None, &Some(common::AA_PARAMETER))
@@ -61,7 +59,5 @@ async fn test_decrypt_layers(#[case] image: &str) {
             .unwrap_err();
     }
 
-    // kill AA when the test is finished
-    aa.kill().await.expect("Failed to stop attestation agent!");
     common::clean().await;
 }

--- a/tests/signature_verification.rs
+++ b/tests/signature_verification.rs
@@ -91,7 +91,7 @@ const SIGSTORE_CONFIG_URI: &str = "kbs:///default/sigstore-config/test";
 async fn signature_verification() {
     common::prepare_test().await;
     // Init AA
-    let mut aa = common::start_attestation_agent()
+    let _aa = common::start_attestation_agent()
         .await
         .expect("Failed to start attestation agent!");
 
@@ -142,7 +142,5 @@ async fn signature_verification() {
         }
     }
 
-    // kill AA when the test is finished
-    aa.kill().await.expect("Failed to stop attestation agent!");
     common::clean().await;
 }


### PR DESCRIPTION
- If the AA process for integration tests fails to come up properly the tests do not abort.
- On failed tests the AA process is not killed, because the teardown fn is not called.
- Garbage collection of tempfile::tempdir doesn't work for overlayfs mounted bundles

The changes probe for an unexpected exit, instruct tokio to kill the process on `drop()` of the `Command`, and umount the rootfs on a successful pull

```bash
running 1 test
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: transport error

Caused by:
    0: error creating server listener: Address already in use (os error 98)
    1: Address already in use (os error 98)', app/src/main.rs:31:37
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test test_decrypt_layers::case_1 ... FAILED

failures:

---- test_decrypt_layers::case_1 stdout ----
thread 'test_decrypt_layers::case_1' panicked at 'Attestation Agent failed to start', tests/common/mod.rs:108:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_decrypt_layers::case_1

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.05s
```